### PR TITLE
Revert to root basepath for registry.bazel.build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   // for hosting under GitHub pages
-  basePath: '/bazel-central-registry'
+  basePath: '',
 }
 
 module.exports = nextConfig

--- a/pages/all-modules.tsx
+++ b/pages/all-modules.tsx
@@ -24,7 +24,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
     <div className="flex flex-col">
       <Head>
         <title>Bazel Central Registry</title>
-        <link rel="icon" href="/bazel-central-registry/favicon.png" />
+        <link rel="icon" href="/favicon.png" />
       </Head>
 
       <Header />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -63,7 +63,7 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
     <div className="flex flex-col">
       <Head>
         <title>Bazel Central Registry</title>
-        <link rel="icon" href="/bazel-central-registry/favicon.png" />
+        <link rel="icon" href="/favicon.png" />
       </Head>
 
       <Header />

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -16,6 +16,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { faEnvelope } from '@fortawesome/free-regular-svg-icons'
 import { CopyCode } from '../../components/CopyCode'
+import React from 'react'
 
 interface ModulePageProps {
   metadata: Metadata
@@ -42,7 +43,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
     <div className="flex flex-col">
       <Head>
         <title>{`Bazel Central Registry | ${module}`}</title>
-        <link rel="icon" href="/bazel-central-registry/favicon.png" />
+        <link rel="icon" href="/favicon.png" />
       </Head>
 
       <Header />

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -66,7 +66,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
     <div className="flex flex-col">
       <Head>
         <title>Bazel Central Registry</title>
-        <link rel="icon" href="/bazel-central-registry/favicon.png" />
+        <link rel="icon" href="/favicon.png" />
       </Head>
 
       <Header />

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-bcr.hobofan.com
+registry.bazel.build


### PR DESCRIPTION
Reverts some of the changes from #7, in preparation for hosting under registry.bazel.build