### PR TITLE
fix: bzlmod modules -> bazel modules

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -73,7 +73,7 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
             Bazel Central Registry
           </h1>
           <div className="text-bzl-green text-4xl">
-            Home of all your bzlmod modules!
+            Home of all your bazel modules!
           </div>
           <div className="mt-4 ml-2 px-2 rounded bg-amber-300">
             As of Bazel 5.X, bzlmod and the Bazel Central Registry are in an


### PR DESCRIPTION
It feels like "bzlmod" is implied that it's short for "bazel modules", so "bzlmod modules" doesn't make sense to me. Switches the title to "Home of all your bazel modules!"