### PR TITLE
Sort versions interpreted as SemVer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
+    "compare-versions": "^4.1.3",
     "date-fns": "^2.28.0",
     "execa": "^6.1.0",
     "fuse.js": "^6.6.2",

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -1,4 +1,5 @@
 import type { GetStaticProps, NextPage } from 'next'
+import compareVersions from 'compare-versions';
 import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -208,16 +209,18 @@ export interface VersionInfo {
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const { module } = params as any
   const metadata = await getModuleMetadata(module)
+  const { versions } = metadata;
+  versions.sort(compareVersions)
 
   const versionInfos: VersionInfo[] = await Promise.all(
-    metadata.versions.map(async (version) => ({
+    versions.map(async (version) => ({
       version,
       submission: await getSubmissionCommitOfVersion(module, version),
       moduleInfo: await extractModuleInfo(module, version),
     }))
   )
 
-  const latestVersion = metadata.versions[metadata.versions.length - 1]
+  const latestVersion = versions[metadata.versions.length - 1]
   const selectedVersion = latestVersion
 
   return {

--- a/pages/modules/[module]/[version].tsx
+++ b/pages/modules/[module]/[version].tsx
@@ -7,13 +7,16 @@ import {
   listModuleNames,
   listModuleVersions,
 } from '../../../data/utils'
+import compareVersions from 'compare-versions'
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const { module, version } = params as any
   const metadata = await getModuleMetadata(module)
+  const { versions } = metadata;
+  versions.sort(compareVersions)
 
   const versionInfos: VersionInfo[] = await Promise.all(
-    metadata.versions.map(async (version) => ({
+    versions.map(async (version) => ({
       version,
       submission: await getSubmissionCommitOfVersion(module, version),
       moduleInfo: await extractModuleInfo(module, version),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   '@types/react': 18.0.12
   '@types/react-dom': 18.0.5
   autoprefixer: ^10.4.7
+  compare-versions: ^4.1.3
   date-fns: ^2.28.0
   eslint: 8.17.0
   eslint-config-next: 12.1.6
@@ -32,6 +33,7 @@ dependencies:
   '@fortawesome/free-regular-svg-icons': 6.1.1
   '@fortawesome/free-solid-svg-icons': 6.1.1
   '@fortawesome/react-fontawesome': 0.1.18_sdfg7szeivrzzj63kiqxwaxkwu
+  compare-versions: 4.1.3
   date-fns: 2.28.0
   execa: 6.1.0
   fuse.js: 6.6.2
@@ -624,6 +626,10 @@ packages:
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
+
+  /compare-versions/4.1.3:
+    resolution: {integrity: sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg==}
+    dev: false
 
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}


### PR DESCRIPTION
Addresses #16

I'm not sure whether we can assume that all versions follow the SemVer format (e.g. `abseil-cpp` doesn't), the used library (`compare-versions`) seem to handle this case fine, and at least for all the currently contained modules produces a sensible sorting.