### PR TITLE
Fix broken sorting on module page based on navigation

### DIFF
--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -72,7 +72,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
                 <h2 className="text-2xl font-bold mt-4">Version history</h2>
                 <div>
                   <ul className="mt-4">
-                    {versionInfos.reverse().map((version) => (
+                    {versionInfos.slice().reverse().map((version) => (
                       <li
                         key={version.version}
                         className="border rounded p-2 mt-2 flex items-stretch gap-4"


### PR DESCRIPTION
CLOSES #24

As `.reverse()` does an in-place reverse, rather than one that returns a reversed clone of the array, we mutated the props, which is a big no-no. With cloning it before via a `slice()` we circumvent that and get a consistent result between client-side rendering and SSR.