### PR TITLE
feat: show link to release notes

### DIFF
--- a/components/CopyCode.tsx
+++ b/components/CopyCode.tsx
@@ -26,7 +26,7 @@ export const CopyCode: React.FC<CopyCodeProps> = ({ code }) => {
     <>
       <button
         ref={reference}
-        className="w-full flex justify-between items-center p-2 mt-4 rounded bg-gray-200 group hover:bg-gray-100 border hover:border-gray-800 cursor-pointer"
+        className="w-full flex justify-between items-center p-2 my-4 rounded bg-gray-200 group hover:bg-gray-100 border hover:border-gray-800 cursor-pointer"
         title="Copy MODULE.bazel snippet to clipboard"
         onClick={handleClickCopy}
       >

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -21,6 +21,7 @@ export interface Metadata {
     github?: string
     name?: string
   }>
+  repository?: string[]
   versions: Array<string>
   yanked_versions: {
     [key: string]: string
@@ -133,7 +134,7 @@ interface Dependency {
 }
 
 /**
- * Extract infromation from `MODULE.bazel` file via buildozer
+ * Extract information from `MODULE.bazel` file via buildozer
  */
 export const extractModuleInfo = async (
   module: string,

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -48,6 +48,9 @@ const ModulePage: NextPage<ModulePageProps> = ({
   const versionInfo = versionInfos.find((n) => n.version === selectedVersion)
   const versionsInOrder = versionInfos.slice().reverse()
 
+  const githubLink = metadata.repository?.find(repo => repo.startsWith('github:'))?.replace('github:', 'https://github.com/')
+  const releaseNotesLink = githubLink ? `${githubLink}/releases/tag/v${selectedVersion}` : undefined
+
   const shownVersions = triggeredShowAll
     ? versionsInOrder
     : versionsInOrder.slice(0, NUM_VERSIONS_ON_PAGE_LOAD)
@@ -86,6 +89,15 @@ const ModulePage: NextPage<ModulePageProps> = ({
                   <CopyCode
                     code={`bazel_dep(name = "${module}", version = "${selectedVersion}")`}
                   />
+                  {!!releaseNotesLink && (
+                    <p>Read the <a
+                    href={releaseNotesLink}
+                    className="text-link-color hover:text-link-color-hover"
+                  >
+                     Release Notes
+                  </a>
+                  </p>
+                  )}
                 </div>
                 <h2 className="text-2xl font-bold mt-4">Version history</h2>
                 <div>


### PR DESCRIPTION
This assumes that the tag on the github repo has a 'v' prefix, which isn't required. I don't think we have enough information from BCR to know any better however.

Fixes #35