### PR TITLE
chore: clarify wording on link

### DIFF
--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -129,7 +129,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
                                     href={`https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/${module}/${version.version}`}
                                     className="text-link-color hover:text-link-color-hover"
                                   >
-                                    view in repository
+                                    view registry source
                                   </a>
                                   <a
                                     href={`https://github.com/bazelbuild/bazel-central-registry/commit/${version.submission.hash}`}


### PR DESCRIPTION
I thought 'view in repository' would take me to the ruleset repo, but it goes to the registry repo