### PR TITLE
Add links to report and website source to footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,13 +2,21 @@ import React from "react";
 
 interface FooterProps { }
 
-export const USER_GUIDE_LINK = "https://bazel.build/docs/bzlmod"
-export const CONTRIBUTE_CTA_LINK = "https://github.com/bazelbuild/bazel-central-registry#roles"
+export const REPORT_LINK = "https://github.com/bazelbuild/bazel-central-registry/tree/main/docs#requesting-to-take-down-a-module"
+export const BCR_UI_REPO_LINK = "https://github.com/bazel-contrib/bcr-ui"
 
 export const Footer: React.FC<FooterProps> = () => {
   return (
-      <footer className="flex items-center justify-center h-10 bottom-0">
-        The Bazel Central Registry is maintained by the Bazel team and the Bazel Rules authors SIG
+      <footer className="flex flex-col items-center justify-center gap-2 h-18 mt-4 bottom-2">
+        <div className="text-center">
+            The Bazel Central Registry is maintained by the Bazel team and the Bazel Rules authors SIG.
+        </div>
+        <div className="text-center">
+          To report an issue with one of the modules, see the <a href={REPORT_LINK} className="text-link-color hover:text-link-color-hover">instructions here</a>.
+        </div>
+        <div className="text-center">
+          The source of this website can be found in <a href={BCR_UI_REPO_LINK} className="text-link-color hover:text-link-color-hover">this repository</a>.
+        </div>
       </footer>
   )
 }


### PR DESCRIPTION
As requested by @meteorcloudy, adds link with report instructions to the footer (and while I was already there, I added a link to the bcr_ui repo as well).

<img width="706" alt="image" src="https://user-images.githubusercontent.com/601283/208871534-3e9530f1-7b00-4825-949e-e28dc105dca9.png">