### PR TITLE
Add text when not finding any search results

### DIFF
--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -86,9 +86,16 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
           <div className="w-full max-w-4xl">
             <h2 className="font-bold text-lg">Search results</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-4">
-              {searchResults.map(({ module, version }) => (
-                <ModuleCard key={module} {...{ module, version }} />
-              ))}
+              {searchResults && searchResults.length ? (
+                searchResults.map(({ module, version }) => (
+                  <ModuleCard key={module} {...{ module, version }} />
+                ))
+              ) : (
+                <p className="text-gray-600">
+                  No results for "
+                  <span className="text-black">{router.query.q}</span>"
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -13,6 +13,9 @@ interface SearchPageProps {
   searchIndex: SearchIndexEntry[]
 }
 
+const GITHUB_ISSUE_LINK =
+  'https://github.com/bazelbuild/bazel-central-registry/issues/new?assignees=&labels=module+wanted&template=module_wanted.yaml&title=wanted%3A+%5Bgithub+path+of+the+module%2C+e.g.+bazelbuild%2Frules_foo%5D'
+
 const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
   const [searchResults, setSearchResults] = useState<SearchIndexEntry[]>([])
 
@@ -91,10 +94,22 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
                   <ModuleCard key={module} {...{ module, version }} />
                 ))
               ) : (
-                <p className="text-gray-600">
-                  No results for "
-                  <span className="text-black">{router.query.q}</span>"
-                </p>
+                <div className="text-gray-600">
+                  <p>
+                    No results for "
+                    <span className="text-black">{router.query.q}</span>".
+                  </p>
+                  <p>
+                    You can{' '}
+                    <a
+                      href={GITHUB_ISSUE_LINK}
+                      className="text-link-color hover:text-link-color-hover"
+                    >
+                      open an issue on GitHub
+                    </a>{' '}
+                    to request the module.
+                  </p>
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
I find that not showing anything at all when no matches are found is not really confidence inspiring for some reason. I really prefer having a "no matches found" text of some sort.

<img width="1530" alt="Bildschirm­foto 2023-01-06 um 18 46 39" src="https://user-images.githubusercontent.com/68024/211069228-5b4d0527-09d5-4a20-bb8e-11c52e1b052c.png">

Closes #34 
