### PR TITLE
Fix unique key for maintainer list

### DIFF
--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -213,7 +213,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
                   <div>
                     <ul>
                       {metadata.maintainers.map(({ name, email, github }) => (
-                        <li key="name">
+                        <li key={name}>
                           <span>
                             {email && (
                               <a


### PR DESCRIPTION
This fixes

```
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <ul>. See https://reactjs.org/link/warning-keys for more information.
```

on a modules details page.