### PR TITLE
Configure & run prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,5 @@
 .github/
 bazel-*
 node_modules
+out/
 pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+**/.next/**
+**/_next/**
+.github/
+bazel-*
+node_modules
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ To learn more about Next.js, take a look at the following resources:
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
-
 ## License
 
 Licensed under Apache License, Version 2.0, ([LICENSE](LICENSE) or http://www.apache.org/licenses/LICENSE-2.0)

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,22 +1,38 @@
-import React from "react";
+import React from 'react'
 
-interface FooterProps { }
+interface FooterProps {}
 
-export const REPORT_LINK = "https://github.com/bazelbuild/bazel-central-registry/tree/main/docs#requesting-to-take-down-a-module"
-export const BCR_UI_REPO_LINK = "https://github.com/bazel-contrib/bcr-ui"
+export const REPORT_LINK =
+  'https://github.com/bazelbuild/bazel-central-registry/tree/main/docs#requesting-to-take-down-a-module'
+export const BCR_UI_REPO_LINK = 'https://github.com/bazel-contrib/bcr-ui'
 
 export const Footer: React.FC<FooterProps> = () => {
   return (
-      <footer className="flex flex-col items-center justify-center gap-2 h-18 mt-4 bottom-2">
-        <div className="text-center">
-            The Bazel Central Registry is maintained by the Bazel team and the Bazel Rules authors SIG.
-        </div>
-        <div className="text-center">
-          To report an issue with one of the modules, see the <a href={REPORT_LINK} className="text-link-color hover:text-link-color-hover">instructions here</a>.
-        </div>
-        <div className="text-center">
-          The source of this website can be found in <a href={BCR_UI_REPO_LINK} className="text-link-color hover:text-link-color-hover">this repository</a>.
-        </div>
-      </footer>
+    <footer className="flex flex-col items-center justify-center gap-2 h-18 mt-4 bottom-2">
+      <div className="text-center">
+        The Bazel Central Registry is maintained by the Bazel team and the Bazel
+        Rules authors SIG.
+      </div>
+      <div className="text-center">
+        To report an issue with one of the modules, see the{' '}
+        <a
+          href={REPORT_LINK}
+          className="text-link-color hover:text-link-color-hover"
+        >
+          instructions here
+        </a>
+        .
+      </div>
+      <div className="text-center">
+        The source of this website can be found in{' '}
+        <a
+          href={BCR_UI_REPO_LINK}
+          className="text-link-color hover:text-link-color-hover"
+        >
+          this repository
+        </a>
+        .
+      </div>
+    </footer>
   )
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "export": "next export",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prettier-check": "prettier --check .",
+    "prettier-fix": "prettier --write ."
   },
   "dependencies": {
     "@floating-ui/react-dom": "^0.7.2",

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -48,8 +48,12 @@ const ModulePage: NextPage<ModulePageProps> = ({
   const versionInfo = versionInfos.find((n) => n.version === selectedVersion)
   const versionsInOrder = versionInfos.slice().reverse()
 
-  const githubLink = metadata.repository?.find(repo => repo.startsWith('github:'))?.replace('github:', 'https://github.com/')
-  const releaseNotesLink = githubLink ? `${githubLink}/releases/tag/v${selectedVersion}` : undefined
+  const githubLink = metadata.repository
+    ?.find((repo) => repo.startsWith('github:'))
+    ?.replace('github:', 'https://github.com/')
+  const releaseNotesLink = githubLink
+    ? `${githubLink}/releases/tag/v${selectedVersion}`
+    : undefined
 
   const shownVersions = triggeredShowAll
     ? versionsInOrder
@@ -90,13 +94,15 @@ const ModulePage: NextPage<ModulePageProps> = ({
                     code={`bazel_dep(name = "${module}", version = "${selectedVersion}")`}
                   />
                   {!!releaseNotesLink && (
-                    <p>Read the <a
-                    href={releaseNotesLink}
-                    className="text-link-color hover:text-link-color-hover"
-                  >
-                     Release Notes
-                  </a>
-                  </p>
+                    <p>
+                      Read the{' '}
+                      <a
+                        href={releaseNotesLink}
+                        className="text-link-color hover:text-link-color-hover"
+                      >
+                        Release Notes
+                      </a>
+                    </p>
                   )}
                 </div>
                 <h2 className="text-2xl font-bold mt-4">Version history</h2>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,16 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./pages/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {
       colors: {
-        'bzl-green': "#0C713A",
-        'link-color': "#00AC5B",
-        'link-color-hover': "#007940",
-      }
+        'bzl-green': '#0C713A',
+        'link-color': '#00AC5B',
+        'link-color-hover': '#007940',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
I noticed that my editor (which is configured to run prettier on save) and the checked in code sometimes disagreed.
Turns out, while prettier is a dev-dependency, it isn't enforced in any way and there were no easy to discover entrypoints in the package file.

This adds

* `npm run prettier-check`
* `npm run prettier-fix`

the first of which we could run in a github workflow if you agree.