### PR TITLE
Fix broken compatibility level when not specified

### DIFF
--- a/data/utils.ts
+++ b/data/utils.ts
@@ -161,7 +161,7 @@ export const extractModuleInfo = async (
     ['print compatibility_level', ':%module'],
     { cwd: directory }
   )
-  const compatibilityLevel = parseInt(compatibilityLevelOut, 10)
+  const compatibilityLevel = parseInt(compatibilityLevelOut, 10) || 0
 
   const { stdout: listDepNamesOut } = await execa(
     BUILDOZER_BIN,


### PR DESCRIPTION
Modules such as https://registry.bazel.build/modules/apple_rules_lint don't have the `compatibility_level` set in their MODULE.bazel files. This is fine, since that is an optional attr with a default, see https://bazel.build/rules/lib/globals#module

However, querying for that attr returns `(missing)`, which is parsed to `NaN` and leads to the dreaded "hydration error" in next js during development, and of course to nothing being rendered in the final output in prod.

Falling back to the default of `0` fixes that.