### PR TITLE
Fix lints for unescaped quotes

### DIFF
--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -96,8 +96,8 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
               ) : (
                 <div className="text-gray-600">
                   <p>
-                    No results for "
-                    <span className="text-black">{router.query.q}</span>".
+                    No results for &quot;
+                    <span className="text-black">{router.query.q}</span>&quot;.
                   </p>
                   <p>
                     You can{' '}


### PR DESCRIPTION
```
99:36  Error: `"` can be escaped with `&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`.  react/no-unescaped-entities
100:73  Error: `"` can be escaped with `&quot;`, `&ldquo;`, `&#34;`, `&rdquo;`.  react/no-unescaped-entities
```

I introduced those accidentally with #43, see failing deploy on main branch