### PR TITLE
Hotfix version parsing breaking build by ignoring non-semver

### DIFF
--- a/data/moduleStaticProps.ts
+++ b/data/moduleStaticProps.ts
@@ -1,4 +1,4 @@
-import compareVersions from 'compare-versions'
+import { compareVersions, validate as validateVersion } from 'compare-versions'
 import {
   extractModuleInfo,
   getModuleMetadata,
@@ -24,8 +24,8 @@ export const getStaticPropsModulePage = async (
   version: string | null
 ) => {
   const metadata = await getModuleMetadata(module)
-  const { versions } = metadata
-  versions.sort(compareVersions)
+  let { versions } = metadata
+  versions = sortVersions(versions)
 
   const versionInfos: VersionInfo[] = await Promise.all(
     versions.map(async (version) => ({
@@ -47,4 +47,22 @@ export const getStaticPropsModulePage = async (
       selectedVersion,
     },
   }
+}
+
+/**
+ * Sort versions, by splitting them into sortable and unsortable ones.
+ *
+ * The sortable versions will form the start of the list and are sorted, while the unsortable ones will
+ * form the end of it.
+ *
+ * This is mostly a placeholder until we have proper version parsing and comparison
+ * (see discussion in https://github.com/bazel-contrib/bcr-ui/issues/54).
+ */
+const sortVersions = (versions: string[]): string[] => {
+  const sortableVersions = versions.filter((version) => validateVersion(version))
+  const unsortableVersions = versions.filter((version) => !validateVersion(version))
+  sortableVersions.sort(compareVersions)
+  sortableVersions.reverse()
+
+  return [...sortableVersions,...unsortableVersions];
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
-    "compare-versions": "^4.1.3",
+    "compare-versions": "^6.0.0-rc.1",
     "date-fns": "^2.28.0",
     "execa": "^6.1.0",
     "fuse.js": "^6.6.2",

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -1,17 +1,12 @@
 import type { GetStaticProps, NextPage } from 'next'
-import compareVersions from 'compare-versions'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { Header, USER_GUIDE_LINK } from '../../components/Header'
 import { Footer } from '../../components/Footer'
 import {
-  extractModuleInfo,
-  getModuleMetadata,
-  getSubmissionCommitOfVersion,
   listModuleNames,
   Metadata,
-  ModuleInfo,
 } from '../../data/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
@@ -46,7 +41,6 @@ const ModulePage: NextPage<ModulePageProps> = ({
   const displayShowAllButton = isQualifiedForShowAll && !triggeredShowAll
 
   const versionInfo = versionInfos.find((n) => n.version === selectedVersion)
-  const versionsInOrder = versionInfos.slice().reverse()
 
   const githubLink = metadata.repository
     ?.find((repo) => repo.startsWith('github:'))
@@ -56,8 +50,8 @@ const ModulePage: NextPage<ModulePageProps> = ({
     : undefined
 
   const shownVersions = triggeredShowAll
-    ? versionsInOrder
-    : versionsInOrder.slice(0, NUM_VERSIONS_ON_PAGE_LOAD)
+    ? versionInfos
+    : versionInfos.slice(0, NUM_VERSIONS_ON_PAGE_LOAD)
 
   if (!versionInfo) {
     throw Error(

--- a/pages/modules/[module]/[version].tsx
+++ b/pages/modules/[module]/[version].tsx
@@ -1,13 +1,9 @@
 import ModulePage from '../[module]'
 import { GetStaticProps } from 'next'
 import {
-  extractModuleInfo,
-  getModuleMetadata,
-  getSubmissionCommitOfVersion,
   listModuleNames,
   listModuleVersions,
 } from '../../../data/utils'
-import compareVersions from 'compare-versions'
 import { getStaticPropsModulePage } from '../../../data/moduleStaticProps'
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ specifiers:
   '@types/react': 18.0.12
   '@types/react-dom': 18.0.5
   autoprefixer: ^10.4.7
-  compare-versions: ^4.1.3
+  compare-versions: ^6.0.0-rc.1
   date-fns: ^2.28.0
   eslint: 8.17.0
   eslint-config-next: 12.1.6
@@ -33,7 +33,7 @@ dependencies:
   '@fortawesome/free-regular-svg-icons': 6.1.1
   '@fortawesome/free-solid-svg-icons': 6.1.1
   '@fortawesome/react-fontawesome': 0.1.18_sdfg7szeivrzzj63kiqxwaxkwu
-  compare-versions: 4.1.3
+  compare-versions: 6.0.0-rc.1
   date-fns: 2.28.0
   execa: 6.1.0
   fuse.js: 6.6.2
@@ -627,8 +627,8 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
-  /compare-versions/4.1.3:
-    resolution: {integrity: sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg==}
+  /compare-versions/6.0.0-rc.1:
+    resolution: {integrity: sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ==}
     dev: false
 
   /concat-map/0.0.1:


### PR DESCRIPTION
FIXES #54

- Bump `compare-versions` to latest version
- Split out versions that are non-semver compliant before sorting for the time being