### PR TITLE
Fix wrong version being considered latest version after SemVer sorting changes

### DIFF
--- a/data/moduleStaticProps.ts
+++ b/data/moduleStaticProps.ts
@@ -37,7 +37,7 @@ export const getStaticPropsModulePage = async (
     }))
   )
 
-  const latestVersion = versions[metadata.versions.length - 1]
+  const latestVersion = versions[0]
   const selectedVersion = version || latestVersion
 
   return {


### PR DESCRIPTION
Fixes a change resulting from #55 