### PR TITLE
Re-render relative dates on client side to display correct value

### DIFF
--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,17 +1,22 @@
 import React from 'react'
 import Link from 'next/link'
+import { formatDistance, parseISO } from 'date-fns'
 
 export interface ModuleCardProps {
   module: string
   version: string
-  authorDateRel?: string
+  authorDate?: string
 }
 
 export const ModuleCard: React.FC<ModuleCardProps> = ({
   module,
   version,
-  authorDateRel,
+  authorDate,
 }) => {
+  const authorDateRel = authorDate
+    ? formatDistance(parseISO(authorDate), new Date(), { addSuffix: true })
+    : null
+
   return (
     <Link href={`/modules/${module}`}>
       <a>
@@ -23,7 +28,10 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
             </div>
             <div className="flex">
               {authorDateRel && (
-                <div className="text-gray-500 self-end">
+                <div
+                  className="text-gray-500 self-end"
+                  suppressHydrationWarning
+                >
                   updated {authorDateRel}
                 </div>
               )}

--- a/data/moduleStaticProps.ts
+++ b/data/moduleStaticProps.ts
@@ -11,6 +11,7 @@ export interface VersionInfo {
   submission: {
     hash: string
     authorDate: string
+    authorDateIso: string
     authorDateRel: string
   }
   moduleInfo: ModuleInfo
@@ -59,10 +60,14 @@ export const getStaticPropsModulePage = async (
  * (see discussion in https://github.com/bazel-contrib/bcr-ui/issues/54).
  */
 const sortVersions = (versions: string[]): string[] => {
-  const sortableVersions = versions.filter((version) => validateVersion(version))
-  const unsortableVersions = versions.filter((version) => !validateVersion(version))
+  const sortableVersions = versions.filter((version) =>
+    validateVersion(version)
+  )
+  const unsortableVersions = versions.filter(
+    (version) => !validateVersion(version)
+  )
   sortableVersions.sort(compareVersions)
   sortableVersions.reverse()
 
-  return [...sortableVersions,...unsortableVersions];
+  return [...sortableVersions, ...unsortableVersions]
 }

--- a/data/moduleStaticProps.ts
+++ b/data/moduleStaticProps.ts
@@ -10,9 +10,7 @@ export interface VersionInfo {
   version: string
   submission: {
     hash: string
-    authorDate: string
     authorDateIso: string
-    authorDateRel: string
   }
   moduleInfo: ModuleInfo
   isYanked: boolean

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -48,9 +48,7 @@ export const getModuleMetadata = async (module: string): Promise<Metadata> => {
 export interface SearchIndexEntry {
   module: string
   version: string
-  authorDate: string
   authorDateIso: string
-  authorDateRel: string
 }
 
 export const buildSearchIndex = async (): Promise<SearchIndexEntry[]> => {
@@ -60,14 +58,14 @@ export const buildSearchIndex = async (): Promise<SearchIndexEntry[]> => {
       const metadata = await getModuleMetadata(module)
       const latestVersion = metadata.versions[metadata.versions.length - 1]
 
-      const { authorDate, authorDateRel, authorDateIso } =
-        await getSubmissionCommitOfVersion(module, latestVersion)
+      const { authorDateIso } = await getSubmissionCommitOfVersion(
+        module,
+        latestVersion
+      )
 
       return {
         module,
         version: latestVersion,
-        authorDate,
-        authorDateRel,
         authorDateIso,
       }
     })

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -60,13 +60,8 @@ export const buildSearchIndex = async (): Promise<SearchIndexEntry[]> => {
       const metadata = await getModuleMetadata(module)
       const latestVersion = metadata.versions[metadata.versions.length - 1]
 
-      const { authorDate, authorDateRel } = await getSubmissionCommitOfVersion(
-        module,
-        latestVersion
-      )
-      const authorDateIso = formatISO(
-        parse(authorDate, 'yyyy-MM-dd HH:mm:ss xxxx', new Date())
-      )
+      const { authorDate, authorDateRel, authorDateIso } =
+        await getSubmissionCommitOfVersion(module, latestVersion)
 
       return {
         module,
@@ -82,6 +77,7 @@ export const buildSearchIndex = async (): Promise<SearchIndexEntry[]> => {
 export interface Commit {
   hash: string
   authorDate: string
+  authorDateIso: string
   authorDateRel: string
 }
 
@@ -98,7 +94,14 @@ export const getSubmissionCommitOfVersion = async (
 
   const commits = await gitlogPromise(options)
 
-  return commits[commits.length - 1] as any
+  const commitInfo = commits[commits.length - 1] as any
+  const authorDateIso = formatISO(
+    parse(commitInfo.authorDate, 'yyyy-MM-dd HH:mm:ss xxxx', new Date())
+  )
+  return {
+    ...commitInfo,
+    authorDateIso,
+  }
 }
 
 // TODO: find a more robust way to do this

--- a/pages/all-modules.tsx
+++ b/pages/all-modules.tsx
@@ -33,12 +33,14 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
           <div>
             <h2 className="font-bold text-lg">All modules</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-4">
-              {searchIndex.map(({ module, version, authorDateRel }) => (
-                <ModuleCard
-                  key={module}
-                  {...{ module, version, authorDateRel }}
-                />
-              ))}
+              {searchIndex.map(
+                ({ module, version, authorDateIso: authorDate }) => (
+                  <ModuleCard
+                    key={module}
+                    {...{ module, version, authorDate }}
+                  />
+                )
+              )}
             </div>
           </div>
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -95,10 +95,10 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
               <h2 className="font-bold text-lg">Recently updated</h2>
               <div className="grid grid-cols-1 gap-8 mt-4">
                 {recentlyUpdatedModules.map(
-                  ({ module, version, authorDateRel }) => (
+                  ({ module, version, authorDateIso: authorDate }) => (
                     <ModuleCard
                       key={module}
-                      {...{ module, version, authorDateRel }}
+                      {...{ module, version, authorDate }}
                     />
                   )
                 )}

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -4,10 +4,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { Header, USER_GUIDE_LINK } from '../../components/Header'
 import { Footer } from '../../components/Footer'
-import {
-  listModuleNames,
-  Metadata,
-} from '../../data/utils'
+import { listModuleNames, Metadata } from '../../data/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { faEnvelope } from '@fortawesome/free-regular-svg-icons'
@@ -17,6 +14,7 @@ import {
   getStaticPropsModulePage,
   VersionInfo,
 } from '../../data/moduleStaticProps'
+import { formatDistance, parseISO } from 'date-fns'
 
 interface ModulePageProps {
   metadata: Metadata
@@ -146,8 +144,16 @@ const ModulePage: NextPage<ModulePageProps> = ({
                                   <a
                                     href={`https://github.com/bazelbuild/bazel-central-registry/commit/${version.submission.hash}`}
                                     className="text-link-color hover:text-link-color-hover"
+                                    suppressHydrationWarning
                                   >
-                                    published {version.submission.authorDateRel}
+                                    published{' '}
+                                    {formatDistance(
+                                      parseISO(
+                                        version.submission.authorDateIso
+                                      ),
+                                      new Date(),
+                                      { addSuffix: true }
+                                    )}
                                   </a>
                                 </div>
                               </div>

--- a/pages/modules/[module]/[version].tsx
+++ b/pages/modules/[module]/[version].tsx
@@ -1,9 +1,6 @@
 import ModulePage from '../[module]'
 import { GetStaticProps } from 'next'
-import {
-  listModuleNames,
-  listModuleVersions,
-} from '../../../data/utils'
+import { listModuleNames, listModuleVersions } from '../../../data/utils'
 import { getStaticPropsModulePage } from '../../../data/moduleStaticProps'
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {


### PR DESCRIPTION
CLOSES #27

This will render all relative dates present on the pages again in the browser, so that they show the correct relative values to the current time. As this leads to a DOM that differs from the server-rendered DOM, we need to use `suppressHydrationWarning` for the rendering locations. Without that, we would get some React errors, leading to e.g. broken navigation.

As we now base all rendering on `authorDateIso`, the redundant old variants that contained the pre-rendered relative date string have been removed from the `staticProps`, reducing the size of the data blob that will be served to the frontend.

-----

Flow to test (might be easier with `libfaketime`, but I didn't get that to be respected in the Next.js build):
- Set system time to a value that is close to the latest BCR commit that added a new module
- `pnpm run build && pnpm run export` (The static pages now have some old dates baked in)
- Reset system time to now
- Serve `out` directory via static file server (e.g. `npx serve`) and view in browser