### PR TITLE
Add explainer links for yanked versions & compatibility levels

### DIFF
--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -134,7 +134,12 @@ const ModulePage: NextPage<ModulePageProps> = ({
                               <div className="flex flex-col justify-between">
                                 <div />
                                 <div className="self-end text-gray-500">
-                                  compatibility level{' '}
+                                  <a
+                                    href="https://bazel.build/external/module#compatibility_level"
+                                    className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
+                                  >
+                                    compatibility level
+                                  </a>{' '}
                                   {version.moduleInfo.compatibilityLevel}
                                 </div>
                               </div>

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -111,8 +111,13 @@ const ModulePage: NextPage<ModulePageProps> = ({
                               key={`${version.version}-yanked`}
                               className="p-2 mb-2 bg-amber-300"
                             >
-                              Version yanked with comment:{' '}
-                              <p>{version.yankReason}</p>
+                              <a
+                                href="https://bazel.build/external/module#yanked_versions"
+                                className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
+                              >
+                                Version yanked
+                              </a>{' '}
+                              with comment: <p>{version.yankReason}</p>
                             </div>
                           )}
                           <div className="p-2 flex items-stretch gap-4">


### PR DESCRIPTION
Add explainer links for yanked versions & compatibility levels, indicated by a dashed underline:
<img width="312" alt="image" src="https://github.com/bazel-contrib/bcr-ui/assets/601283/11cbc08e-f14a-4f5f-97c4-89d9f1c585aa">


CLOSES #30 