### PR TITLE
 Adjust version number styling to provie more space

### DIFF
--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -134,7 +134,12 @@ const ModulePage: NextPage<ModulePageProps> = ({
                               <div className="flex flex-col justify-between">
                                 <div />
                                 <div className="self-end text-gray-500">
-                                  compatibility level{' '}
+                                  <a
+                                    href="https://bazel.build/external/module#compatibility_level"
+                                    className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
+                                  >
+                                    compatibility level
+                                  </a>{' '}
                                   {version.moduleInfo.compatibilityLevel}
                                 </div>
                               </div>

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -111,8 +111,13 @@ const ModulePage: NextPage<ModulePageProps> = ({
                               key={`${version.version}-yanked`}
                               className="p-2 mb-2 bg-amber-300"
                             >
-                              Version yanked with comment:{' '}
-                              <p>{version.yankReason}</p>
+                              <a
+                                href="https://bazel.build/external/module#yanked_versions"
+                                className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
+                              >
+                                Version yanked
+                              </a>{' '}
+                              with comment: <p>{version.yankReason}</p>
                             </div>
                           )}
                           <div className="p-2 flex items-stretch gap-4">

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -104,7 +104,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
                       <>
                         <li
                           key={version.version}
-                          className="border rounded mt-2"
+                          className="border rounded mt-2 "
                         >
                           {version.isYanked && (
                             <div
@@ -120,19 +120,18 @@ const ModulePage: NextPage<ModulePageProps> = ({
                               with comment: <p>{version.yankReason}</p>
                             </div>
                           )}
-                          <div className="p-2 flex items-stretch gap-4">
-                            <Link
-                              href={`/modules/${module}/${version.version}`}
-                            >
-                              <a>
-                                <div className="rounded-full border h-14 w-14 grid place-items-center hover:border-gray-800">
-                                  {version.version}
-                                </div>
-                              </a>
-                            </Link>
+                          <div className="flex items-stretch gap-4">
                             <div className="flex flex-1 justify-between">
-                              <div className="flex flex-col justify-between">
-                                <div />
+                              <div className="flex p-2 flex-col gap-2 justify-between border-r hover:border-link-color hover:border-r-4">
+                                <Link
+                                  href={`/modules/${module}/${version.version}`}
+                                >
+                                  <a>
+                                    <div className="place-items-center hover:border-gray-800">
+                                      {version.version}
+                                    </div>
+                                  </a>
+                                </Link>
                                 <div className="self-end text-gray-500">
                                   <a
                                     href="https://bazel.build/external/module#compatibility_level"
@@ -143,7 +142,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
                                   {version.moduleInfo.compatibilityLevel}
                                 </div>
                               </div>
-                              <div className="flex justify-end">
+                              <div className="flex p-2 justify-end">
                                 <div className="flex flex-col justify-between items-end">
                                   <a
                                     href={`https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/${module}/${version.version}`}


### PR DESCRIPTION
Moves away from the circular design for the version number, which only really worked for strict semver number with no more than 4 digits in total. As we do have quite a few non-semver version numbers and pre-releases, the new style provides some more space to accommodate those.

The hover effect is adjusted to a highlight on the right border.

Old:
<img width="703" alt="image" src="https://github.com/bazel-contrib/bcr-ui/assets/601283/32011090-4ea4-46f4-9598-6aa2e5e1b2ff">

New:
<img width="599" alt="image" src="https://github.com/bazel-contrib/bcr-ui/assets/601283/98a636b3-cee2-4735-9591-a8ff1c10d4ce">

(Includes #60, and is supposed to be merged after it)