### PR TITLE
Bump pnpm to 8.6.12

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2.2.2
         with:
-          version: 6.0.2
+          version: 8.6.12
 
       - name: Install required binaries
         run: |


### PR DESCRIPTION
Build is failing after #72, where I accidentally updated the lockfile with a newer version of pnpm.

Rather than rolling it back, let's upgrade to the latest version of pnpm.