### PR TITLE
feat: distinguish types of dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
     sha256 = "29a50ea545810dc077c408d520eb83e9de3eecfe6395e89cb07149d903fc31e5",
     strip_prefix = "buildifier-prebuilt-6.1.2",
     urls = [
-        "http://github.com/keith/buildifier-prebuilt/archive/6.1.2.tar.gz",
+        "https://github.com/keith/buildifier-prebuilt/archive/6.1.2.tar.gz",
     ],
 )
 

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -132,6 +132,7 @@ export interface ModuleInfo {
 }
 
 interface Dependency {
+  dev: boolean
   module: string
   version: string
 }
@@ -176,16 +177,25 @@ export const extractModuleInfo = async (
     ['print version', ':%bazel_dep'],
     { cwd: directory }
   )
+  const { stdout: listDepDevOut } = await execa(
+    BUILDOZER_BIN,
+    ['print dev_dependency', ':%bazel_dep'],
+    { cwd: directory }
+  )
   const depNames = listDepNamesOut.split(/\r?\n/)
   const depVersions = listDepVersionsOut.split(/\r?\n/)
+  const depDevStatuses = listDepDevOut.split(/\r?\n/)
 
   const dependencies: Dependency[] = []
 
   if (listDepVersionsOut !== '') {
     depNames.forEach((name, i) => {
       const version = depVersions[i]
+      const dev = depDevStatuses[i] === 'True'
+
       dependencies.push({
         module: name,
+        dev,
         version,
       } as Dependency)
     })

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -198,59 +198,101 @@ const ModulePage: NextPage<ModulePageProps> = ({
                     </button>
                   )}
                 </div>
-                <h2 className="text-2xl font-bold mt-4">
-                  Dependencies{' '}
-                  <small className="text-sm font-normal text-gray-500">
-                    (of version {selectedVersion})
-                  </small>
-                </h2>
-                <div>
-                  <ul className="mt-4">
-                    {versionInfo.moduleInfo.dependencies.map((dependency) => (
-                      <Link
-                        key={dependency.module}
-                        href={`/modules/${dependency.module}/${dependency.version}`}
-                      >
-                        <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
-                          <div className="rounded-full border h-14 w-14 grid place-items-center">
-                            {dependency.version}
-                          </div>
-                          <div>{dependency.module}</div>
-                        </li>
-                      </Link>
-                    ))}
-                    {versionInfo.moduleInfo.dependencies.length === 0 && (
-                      <span>No dependencies</span>
-                    )}
-                  </ul>
+                <div className="mt-4">
+                  <h2 className="text-2xl font-bold mt-4">Dependency graph</h2>
                 </div>
-                <h2 className="text-2xl font-bold mt-4">Dependents</h2>
-                <div>
-                  <ul className="mt-4">
-                    {shownReverseDependencies.map((revDependency) => (
-                      <Link
-                        key={revDependency}
-                        href={`/modules/${revDependency}`}
+                <div className="mt-4">
+                  <details open>
+                    <summary>
+                      <span role="heading" aria-level={2} className="text-1xl mt-4">
+                        <span className="font-bold">Direct</span> ({versionInfo.moduleInfo.dependencies.filter((d) => !d.dev).length || 'None'}){' '}
+                        <small className="text-sm font-normal text-gray-500">
+                          at version {selectedVersion}
+                        </small>
+                      </span>
+                    </summary>
+                    <ul className="mt-4">
+                      {versionInfo.moduleInfo.dependencies.filter((d) => !d.dev).map((dependency) => (
+                        <Link
+                          key={dependency.module}
+                          href={`/modules/${dependency.module}/${dependency.version}`}
+                        >
+                          <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
+                            <div className="rounded-full border h-14 w-14 grid place-items-center">
+                              {dependency.version}
+                            </div>
+                            <div>{dependency.module}</div>
+                          </li>
+                        </Link>
+                      ))}
+                      {versionInfo.moduleInfo.dependencies.filter((d) => !d.dev).length === 0 && (
+                        <span>No dependencies</span>
+                      )}
+                    </ul>
+                  </details>
+                </div>
+                <div className="mt-4">
+                  <details>
+                    <summary>
+                      <span role="heading" aria-level={2} className="text-1xl mt-4">
+                        <span className="font-bold">
+                          Dev Dependencies
+                        </span> ({versionInfo.moduleInfo.dependencies.filter((d) => d.dev).length || 'None'}){' '}
+                      </span>
+                    </summary>
+                    <ul className="mt-4">
+                      {versionInfo.moduleInfo.dependencies.filter((d) => d.dev).map((dependency) => (
+                        <Link
+                          key={dependency.module}
+                          href={`/modules/${dependency.module}/${dependency.version}`}
+                        >
+                          <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
+                            <div className="rounded-full border h-14 w-14 grid place-items-center">
+                              {dependency.version}
+                            </div>
+                            <div>{dependency.module}</div>
+                          </li>
+                        </Link>
+                      ))}
+                      {versionInfo.moduleInfo.dependencies.length === 0 && (
+                        <span>No dependencies</span>
+                      )}
+                    </ul>
+                  </details>
+                </div>
+                <div className="mt-4">
+                  <details>
+                    <summary>
+                      <span role="heading" aria-level={2} className="text-1xl mt-4">
+                        <span className="font-bold">Dependents</span> {shownReverseDependencies.length > 0 ? `(${shownReverseDependencies.length})` : ''}
+                      </span>
+                    </summary>
+                    <ul className="mt-4">
+                      {shownReverseDependencies.map((revDependency) => (
+                        <Link
+                          key={revDependency}
+                          href={`/modules/${revDependency}`}
+                        >
+                          <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
+                            <div>{revDependency}</div>
+                          </li>
+                        </Link>
+                      ))}
+                      {reverseDependencies.length === 0 && (
+                        <span>No dependent modules yet</span>
+                      )}
+                    </ul>
+                    {displayShowAllReverseDependenciesButton && (
+                      <button
+                        className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
+                        onClick={() =>
+                          setTriggeredShowAllReverseDependencies(true)
+                        }
                       >
-                        <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
-                          <div>{revDependency}</div>
-                        </li>
-                      </Link>
-                    ))}
-                    {reverseDependencies.length === 0 && (
-                      <span>No dependent modules</span>
+                        Show all {reverseDependencies.length} dependent modules
+                      </button>
                     )}
-                  </ul>
-                  {displayShowAllReverseDependenciesButton && (
-                    <button
-                      className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
-                      onClick={() =>
-                        setTriggeredShowAllReverseDependencies(true)
-                      }
-                    >
-                      Show all {reverseDependencies.length} dependent modules
-                    </button>
-                  )}
+                  </details>
                 </div>
               </div>
               <div id="metadata" className="mt-4 sm:pl-2 basis-8 grow">


### PR DESCRIPTION
## Summary

This PR adds a new section to the module detail page under the heading _Dependency graph_; in this section, accordions are shown for the package's dependency relationships:

- Transitive packages (the most meaningful to a package consumer)
- Dev packages (not meaningful to a package consumer, maybe meaningful to contributors)
- Dependents (lightly meaningful to all stakeholders)

This UI optimizes for the above goals, with the _Transitive_ package accordion **open by default**, and the others closed, but with **counts added** so that a package's popularity / relevance in the wider package graph can be understood with a quick glance.

_Background:_ I just shipped [`rules_graalvm`](https://registry.bazel.build/modules/rules_graalvm), my first BCR package. Due to the polyglot nature of GraalVM, I need to depend on a lot of different rule packages as dev dependencies. I want to make sure downstream users of my package are aware that _they_ don't need to depend on all these packages.

Fixes and closes #62

## UI Preview

> **New section** in detail:

<img width="1233" alt="before-after-v3" src="https://github.com/bazel-contrib/bcr-ui/assets/171897/9d790e26-d9f1-4a01-bec7-ae1fec49f656">

> _Compare the **perceived transitive cost** of these two screenshots. They depict the [exact same library](https://registry.bazel.build/modules/rules_graalvm), but with much less mental overhead for a clearer picture._

----

> **Side by side:**

<img width="2664" alt="Screenshot 2023-09-08 at 3 07 54 AM" src="https://github.com/bazel-contrib/bcr-ui/assets/171897/296e251c-76e3-43ed-a2ce-7f6ceba0d897">

----

### Subtle details

- This PR is layered on top of #102 because it won't properly build otherwise
- Aria attributes were used to preserve heading roles, so there should be no accessibility impact despite different tags
- Completely native to HTML (no added JS, no added CSS)
