### PR TITLE
fix: easier copy/paste of package name and version

### DIFF
--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -88,14 +88,15 @@ const ModulePage: NextPage<ModulePageProps> = ({
         <div className="max-w-4xl w-4xl mx-auto mt-8">
           <div className="border rounded p-4 divide-y">
             <div>
-              <span className="text-3xl">{module}</span>
-              <span className="text-lg ml-2">{selectedVersion}</span>
+              <span className="selectable text-3xl">{module}</span>
+              <span>&nbsp;</span>{/* helps with dbl-click selection */}
+              <span className="selectable text-lg ml-2">{selectedVersion}</span>
             </div>
             <div className="mt-4 flex flex-wrap sm:divide-x gap-2">
               <div className="basis-0 grow-[999]">
                 <h2 className="text-2xl font-bold mt-4">Install</h2>
                 <div className="mt-2">
-                  <p>
+                  <p className="decorative">
                     To start using this module, make sure you have set up Bzlmod
                     according to the <a href={USER_GUIDE_LINK}>user guide</a>,
                     and add the following to your <code>MODULE.bazel</code>{' '}
@@ -116,7 +117,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
                     </p>
                   )}
                 </div>
-                <h2 className="text-2xl font-bold mt-4">Version history</h2>
+                <h2 className="text-2xl font-bold mt-6 decorative">Version history</h2>
                 <div>
                   <ul className="mt-4">
                     {shownVersions.map((version) => (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,3 +18,5 @@ a {
 * {
   box-sizing: border-box;
 }
+
+@import "./page-module.css";

--- a/styles/page-module.css
+++ b/styles/page-module.css
@@ -1,0 +1,10 @@
+
+/** Page: modules/[module].tsx */
+
+.selectable {
+    user-select: all;
+}
+
+.decorative {
+    user-select: none;
+}


### PR DESCRIPTION
## Summary

At the moment, it an be difficult on BCR to copy _only the package name_ or _version_ value, rather than the full code snippet. By adding an `&nbsp;` between the two `<span>`s and applying a small CSS fix, the selection can be bounded by the package name and version rather than copying both.

The effect is subtle but makes it much easier to copy/paste from these values, see below:

**Before:**
<img width="499" alt="Screenshot 2023-09-11 at 1 51 09 PM" src="https://github.com/bazel-contrib/bcr-ui/assets/171897/5f449ad4-0ddd-4730-bbc5-d492f1ad2409">

**After:**
<img width="492" alt="Screenshot 2023-09-11 at 1 51 21 PM" src="https://github.com/bazel-contrib/bcr-ui/assets/171897/d0fd3095-4c8f-4481-b23e-c3b2bc0ccff1">


## Changelog

- fix: add non-breaking space between package name and version to allow for copying/pasting each one easily
- fix: add css declaration to make copy/paste easier for package name and version