### PR TITLE
fix: `cursor: pointer` for dependency accordions

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,3 +18,8 @@ a {
 * {
   box-sizing: border-box;
 }
+
+details summary {
+  cursor: pointer;
+  user-select: none;
+}


### PR DESCRIPTION
## Summary

Enhances #103 by applying the following to accordion UI (`details summary` elements):
- `cursor: pointer`
- `user-select: none`

### UI Preview

| **Before** | **After** |
| ---------- | --------- |
| <img width="497" alt="Screenshot 2023-09-11 at 5 30 03 PM" src="https://github.com/bazel-contrib/bcr-ui/assets/171897/3d4ecff7-b0ae-4f01-9210-ab8afe420e26"> | <img width="498" alt="Screenshot 2023-09-11 at 5 30 15 PM" src="https://github.com/bazel-contrib/bcr-ui/assets/171897/da3b192b-85ba-4a2b-b749-a4758c129024"> |

> Video preview down below 👇🏻 

## Changelog

- fix: use `cursor: pointer` for `details summary` elements
- fix: use `user-select: none` to prevent accidental highlight of accordion summary elements