### PR TITLE
Adjust workflow to test pull requests 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - '*/*'       # matches every branch containing a single '/'
       - '**'        # matches every branch
       - '!main'     # excludes `main` (where we have the `deploy` workflow
+  pull_request:
+
 jobs:
   build-and-deploy:
     concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.


### PR DESCRIPTION
Also run test workflow on `pull_request` events. Not doing that is how #119 slipped by, as well as a prettier formatting issue that managed to slip into main.

I think this didn't surface earlier, as I was pushing to branches on this repository (and not my fork), where tests were run correctly.