### PR TITLE
Be resilient to certain missing fields in metadata.json

### DIFF
--- a/data/moduleStaticProps.ts
+++ b/data/moduleStaticProps.ts
@@ -27,14 +27,15 @@ export const getStaticPropsModulePage = async (
   const metadata = await getModuleMetadata(module)
   let { versions } = metadata
   versions = sortVersions(versions)
+  let yankedVersions = metadata.yanked_versions || {}
 
   const versionInfos: VersionInfo[] = await Promise.all(
     versions.map(async (version) => ({
       version,
       submission: await getSubmissionCommitOfVersion(module, version),
       moduleInfo: await moduleInfo(module, version),
-      isYanked: Object.keys(metadata.yanked_versions).includes(version),
-      yankReason: metadata.yanked_versions[version] || null,
+      isYanked: Object.keys(yankedVersions).includes(version),
+      yankReason: yankedVersions[version] || null,
     }))
   )
 

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -17,14 +17,14 @@ export const BUILDOZER_BIN = path.join(process.cwd(), 'bin', 'buildozer')
 
 export interface Metadata {
   homepage?: string
-  maintainers: Array<{
+  maintainers?: Array<{
     email?: string
     github?: string
     name?: string
   }>
   repository?: string[]
   versions: Array<string>
-  yanked_versions: {
+  yanked_versions?: {
     [key: string]: string
   }
 }

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -336,7 +336,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
                   <h3 className="font-bold text-xl mt-2">Maintainers</h3>
                   <div>
                     <ul>
-                      {metadata.maintainers.map(({ name, email, github }) => (
+                      {metadata.maintainers?.map(({ name, email, github }) => (
                         <li key={name}>
                           <span>
                             {email && (


### PR DESCRIPTION
Including `yanked_versions` and `maintainers`

Fixes https://github.com/bazel-contrib/bcr-ui/issues/134