### PR TITLE
Fix submission commit detection caching being too agressive

### DIFF
--- a/data/utils.ts
+++ b/data/utils.ts
@@ -108,7 +108,10 @@ const getSubmissionCommitOfVersionInternal = async (
 }
 
 export const getSubmissionCommitOfVersion = pMemoize(
-  getSubmissionCommitOfVersionInternal
+  getSubmissionCommitOfVersionInternal,
+  {
+    cacheKey: (arguments_) => JSON.stringify(arguments_),
+  }
 )
 
 // TODO: find a more robust way to do this


### PR DESCRIPTION
FIXES #140 

`pMemoize` only uses the first argument to cache by default, so we only determined one submisssion commit for a version of a module and then re-used the same commit for all versions of the module.

This adjusts it to use the full arguments (module name + module version) as the cache key.