### PR TITLE
Fix "Install pnpm" error about "invalid this"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v2.4.1
         with:
           version: 8.6.12
 


### PR DESCRIPTION
See https://github.com/pnpm/action-setup/releases/tag/v2.4.1

Sample failure: https://github.com/bazel-contrib/bcr-ui/actions/runs/9878535597/job/27282696349

Fixes https://github.com/bazel-contrib/bcr-ui/issues/146