### PR TITLE
Increase static page generation timeout 60s -> 600s

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,9 @@ const nextConfig = {
   reactStrictMode: true,
   // for hosting under GitHub pages
   basePath: '',
+  // Increase timeout for generating static pages from default 60s to avoid issues like:
+  // Restarted static page generation for /modules/xxx/y.y.y because it took more than 60 seconds
+  staticPageGenerationTimeout: 600
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Looks like in on-bcr-trigger action was failing for last 3 days and there are stale results on the BCR page.

See also https://github.com/bazel-contrib/bcr-ui/issues/153