### PR TITLE
Add visual indicator for attestation

### DIFF
--- a/components/AttestationBadge.tsx
+++ b/components/AttestationBadge.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export interface AttestationBadgeProps {
+  hasAttestationFile: boolean
+}
+
+export const AttestationBadge: React.FC<AttestationBadgeProps> = ({
+  hasAttestationFile,
+}) => {
+  if (!hasAttestationFile) {
+    return null
+  }
+
+  return (
+    <span
+      className="text-blue-600 font-bold text-lg cursor-help"
+      title="This release includes a provenance attestation, which is verifiable proof that it was built using secure, trusted build infrastructure. See https://github.com/bazelbuild/bazel-central-registry/discussions/2721"
+      aria-label="Attested release provenance"
+      role="img"
+    >
+      ✓
+    </span>
+  )
+}

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -1,17 +1,20 @@
 import React from 'react'
 import Link from 'next/link'
 import { formatDistance, parseISO } from 'date-fns'
+import { AttestationBadge } from './AttestationBadge'
 
 export interface ModuleCardProps {
   module: string
   version: string
   authorDate?: string
+  hasAttestationFile?: boolean
 }
 
 export const ModuleCard: React.FC<ModuleCardProps> = ({
   module,
   version,
   authorDate,
+  hasAttestationFile = false,
 }) => {
   const authorDateRel = authorDate
     ? formatDistance(parseISO(authorDate), new Date(), { addSuffix: true })
@@ -23,7 +26,10 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
         <div className="w-full p-4 flex justify-between">
           <div>
             <div className="font-bold">{module}</div>
-            <div>{version}</div>
+            <div className="flex items-center gap-2">
+              {version}
+              <AttestationBadge hasAttestationFile={hasAttestationFile} />
+            </div>
           </div>
           <div className="flex">
             {authorDateRel && (

--- a/data/moduleStaticProps.ts
+++ b/data/moduleStaticProps.ts
@@ -2,6 +2,7 @@ import {
   extractModuleInfo,
   getModuleMetadata,
   getSubmissionCommitOfVersion,
+  hasAttestationFile,
   moduleInfo,
   ModuleInfo,
   reverseDependencies,
@@ -16,6 +17,7 @@ export interface VersionInfo {
   moduleInfo: ModuleInfo
   isYanked: boolean
   yankReason: string | null
+  hasAttestationFile: boolean
 }
 
 // [module]/[version] needs to reuse the same logic
@@ -35,6 +37,7 @@ export const getStaticPropsModulePage = async (
       moduleInfo: await moduleInfo(module, version),
       isYanked: Object.keys(yankedVersions).includes(version),
       yankReason: yankedVersions[version] || null,
+      hasAttestationFile: await hasAttestationFile(module, version),
     }))
   )
 

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -54,6 +54,7 @@ export interface SearchIndexEntry {
   module: string
   version: string
   authorDateIso: string
+  hasAttestationFile: boolean
 }
 
 export const buildSearchIndex = async (): Promise<SearchIndexEntry[]> => {
@@ -72,6 +73,7 @@ export const buildSearchIndex = async (): Promise<SearchIndexEntry[]> => {
         module,
         version: latestVersion,
         authorDateIso,
+        hasAttestationFile: await hasAttestationFile(module, latestVersion),
       }
     })
   )

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -275,6 +275,25 @@ export const moduleInfo = async (
   return all.allModules[module][version]
 }
 
+export const hasAttestationFile = async (
+  module: string,
+  version: string
+): Promise<boolean> => {
+  const attestationsFilePath = path.join(
+    MODULES_ROOT_DIR,
+    module,
+    version,
+    'attestations.json'
+  )
+  
+  try {
+    await fs.access(attestationsFilePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export const reverseDependencies = async (
   module: string
 ): Promise<string[]> => {

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -285,7 +285,7 @@ export const hasAttestationFile = async (
     version,
     'attestations.json'
   )
-  
+
   try {
     await fs.access(attestationsFilePath)
     return true

--- a/pages/all-modules.tsx
+++ b/pages/all-modules.tsx
@@ -34,10 +34,15 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
             <h2 className="font-bold text-lg">All modules</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-4">
               {searchIndex.map(
-                ({ module, version, authorDateIso: authorDate }) => (
+                ({
+                  module,
+                  version,
+                  authorDateIso: authorDate,
+                  hasAttestationFile,
+                }) => (
                   <ModuleCard
                     key={module}
-                    {...{ module, version, authorDate }}
+                    {...{ module, version, authorDate, hasAttestationFile }}
                   />
                 )
               )}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -83,19 +83,29 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
             <div>
               <h2 className="font-bold text-lg">Highlighted modules</h2>
               <div className="grid grid-cols-1 gap-8 mt-4">
-                {highlightedModules.map(({ module, version }) => (
-                  <ModuleCard key={module} {...{ module, version }} />
-                ))}
+                {highlightedModules.map(
+                  ({ module, version, hasAttestationFile }) => (
+                    <ModuleCard
+                      key={module}
+                      {...{ module, version, hasAttestationFile }}
+                    />
+                  )
+                )}
               </div>
             </div>
             <div>
               <h2 className="font-bold text-lg">Recently updated</h2>
               <div className="grid grid-cols-1 gap-8 mt-4">
                 {recentlyUpdatedModules.map(
-                  ({ module, version, authorDateIso: authorDate }) => (
+                  ({
+                    module,
+                    version,
+                    authorDateIso: authorDate,
+                    hasAttestationFile,
+                  }) => (
                     <ModuleCard
                       key={module}
-                      {...{ module, version, authorDate }}
+                      {...{ module, version, authorDate, hasAttestationFile }}
                     />
                   )
                 )}

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -169,8 +169,8 @@ const ModulePage: NextPage<ModulePageProps> = ({
                                   <div className="place-items-center hover:border-gray-800 flex items-center gap-2">
                                     {version.version}
                                     {version.hasAttestationFile && (
-                                      <span 
-                                        className="text-blue-600 font-bold text-lg cursor-help" 
+                                      <span
+                                        className="text-blue-600 font-bold text-lg cursor-help"
                                         title="Cryptographically attested release - This release includes verifiable proof that it was built from the exact source code using secure, trusted build infrastructure. The attestations.json file provides transparent evidence of the build process for enhanced supply chain security."
                                         aria-label="Cryptographically attested release"
                                         role="img"

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -166,8 +166,18 @@ const ModulePage: NextPage<ModulePageProps> = ({
                                 <Link
                                   href={`/modules/${module}/${version.version}`}
                                 >
-                                  <div className="place-items-center hover:border-gray-800">
+                                  <div className="place-items-center hover:border-gray-800 flex items-center gap-2">
                                     {version.version}
+                                    {version.hasAttestationFile && (
+                                      <span 
+                                        className="text-blue-600 font-bold text-lg cursor-help" 
+                                        title="Cryptographically attested release - This release includes verifiable proof that it was built from the exact source code using secure, trusted build infrastructure. The attestations.json file provides transparent evidence of the build process for enhanced supply chain security."
+                                        aria-label="Cryptographically attested release"
+                                        role="img"
+                                      >
+                                        ✓
+                                      </span>
+                                    )}
                                   </div>
                                 </Link>
                                 <div className="self-end text-gray-500">

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { faEnvelope } from '@fortawesome/free-regular-svg-icons'
 import { CopyCode } from '../../components/CopyCode'
+import { AttestationBadge } from '../../components/AttestationBadge'
 import React, { useEffect, useState } from 'react'
 import {
   getStaticPropsModulePage,
@@ -168,16 +169,11 @@ const ModulePage: NextPage<ModulePageProps> = ({
                                 >
                                   <div className="place-items-center hover:border-gray-800 flex items-center gap-2">
                                     {version.version}
-                                    {version.hasAttestationFile && (
-                                      <span
-                                        className="text-blue-600 font-bold text-lg cursor-help"
-                                        title="Cryptographically attested release - This release includes verifiable proof that it was built from the exact source code using secure, trusted build infrastructure. The attestations.json file provides transparent evidence of the build process for enhanced supply chain security."
-                                        aria-label="Cryptographically attested release"
-                                        role="img"
-                                      >
-                                        ✓
-                                      </span>
-                                    )}
+                                    <AttestationBadge
+                                      hasAttestationFile={
+                                        version.hasAttestationFile
+                                      }
+                                    />
                                   </div>
                                 </Link>
                                 <div className="self-end text-gray-500">

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -83,8 +83,11 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
             <h2 className="font-bold text-lg">Search results</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-4">
               {searchResults && searchResults.length ? (
-                searchResults.map(({ module, version }) => (
-                  <ModuleCard key={module} {...{ module, version }} />
+                searchResults.map(({ module, version, hasAttestationFile }) => (
+                  <ModuleCard
+                    key={module}
+                    {...{ module, version, hasAttestationFile }}
+                  />
                 ))
               ) : (
                 <div className="text-gray-600">


### PR DESCRIPTION
A small checkmark is shown if the module has the attestation JSON file. I also added a small tooltip that shows up on hover that briefly explains the concept.


<img width="1728" alt="Screenshot 2025-06-14 at 16 21 04" src="https://github.com/user-attachments/assets/a9c38344-44eb-4d1a-98dd-20efd3c758f0" />


