### PR TITLE
Fix tooltip on attestation badge

### DIFF
--- a/components/AttestationBadge.tsx
+++ b/components/AttestationBadge.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { useFloating } from '@floating-ui/react-dom'
 
 export interface AttestationBadgeProps {
   hasAttestationFile: boolean
@@ -7,18 +8,57 @@ export interface AttestationBadgeProps {
 export const AttestationBadge: React.FC<AttestationBadgeProps> = ({
   hasAttestationFile,
 }) => {
+  const [showTooltip, setShowTooltip] = useState<boolean>(false)
+
+  const { x, y, refs, strategy } = useFloating({
+    placement: 'top',
+  })
+
   if (!hasAttestationFile) {
     return null
   }
 
   return (
-    <span
-      className="text-blue-600 font-bold text-lg cursor-help"
-      title="This release includes a provenance attestation, which is verifiable proof that it was built using secure, trusted build infrastructure. See https://github.com/bazelbuild/bazel-central-registry/discussions/2721"
-      aria-label="Attested release provenance"
-      role="img"
-    >
-      ✓
-    </span>
+    <>
+      <span
+        ref={refs.setReference}
+        className="text-blue-600 font-bold text-lg cursor-help"
+        aria-label="Attested release provenance"
+        role="img"
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+        onFocus={() => setShowTooltip(true)}
+        onBlur={() => setShowTooltip(false)}
+      >
+        ✓
+      </span>
+      {showTooltip && (
+        <div
+          ref={refs.setFloating}
+          style={{
+            position: strategy,
+            top: y ?? 0,
+            left: x ?? 0,
+            zIndex: 1000,
+          }}
+          className="bg-gray-900 text-white text-sm rounded p-3 max-w-sm shadow-lg"
+          onMouseEnter={() => setShowTooltip(true)}
+          onMouseLeave={() => setShowTooltip(false)}
+        >
+          This release includes a provenance attestation, which is verifiable
+          proof that it was built using secure, trusted build infrastructure.
+          See{' '}
+          <a
+            href="https://github.com/bazelbuild/bazel-central-registry/discussions/2721"
+            className="text-blue-300 underline hover:text-blue-200"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+          >
+            https://github.com/bazelbuild/bazel-central-registry/discussions/2721
+          </a>
+        </div>
+      )}
+    </>
   )
 }


### PR DESCRIPTION
Looks like the tooltip is not showing up for some users as discussed [here](https://github.com/bazel-contrib/bcr-ui/pull/162). This approach should work in most browsers.

![Screenshot 2025-06-16 at 18 27 29](https://github.com/user-attachments/assets/698239e9-0924-4c71-9f41-dd99449d1ef7)
