### PR TITLE
renovate: stop updating npm packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "enabledManagers": [
+        "bazel", "bazel-module", "bazelisk", "github-actions"
+  ],
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,5 @@
   "extends": ["config:base"],
   "enabledManagers": [
         "bazel", "bazel-module", "bazelisk", "github-actions"
-  ],
+  ]
 }


### PR DESCRIPTION
We get a lot of automated PRs and don't really care about staying on the latest of these packages. Reduce noise for maintainers.

Similar to https://github.com/bazelbuild/examples/pull/597