### PR TITLE
feat: rework the module page

### DIFF
--- a/components/AttestationBadge.tsx
+++ b/components/AttestationBadge.tsx
@@ -53,16 +53,17 @@ export const AttestationBadge: React.FC<AttestationBadgeProps> = ({
             left: x ?? 0,
             zIndex: 1000,
           }}
-          className="bg-gray-900 text-white text-sm rounded p-3 max-w-sm shadow-lg"
+          className="text-black font-medium text-sm rounded-md p-3 max-w-sm shadow-lg backdrop-blur-lg bg-[#eaf1ed] border-2 border-[#166533]"
           onMouseEnter={() => setShowTooltip(true)}
           onMouseLeave={() => setShowTooltip(false)}
         >
           This release includes a provenance attestation, which is verifiable
           proof that it was built using secure, trusted build infrastructure.
-          See{' '}
+          <br />
+          See:{' '}
           <a
             href="https://github.com/bazelbuild/bazel-central-registry/discussions/2721"
-            className="text-blue-300 underline hover:text-blue-200"
+            className="text-link-color underline hover:text-link-color-hover"
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}

--- a/components/AttestationBadge.tsx
+++ b/components/AttestationBadge.tsx
@@ -1,17 +1,19 @@
 import React, { useState } from 'react'
-import { useFloating } from '@floating-ui/react-dom'
+import { useFloating, Placement } from '@floating-ui/react-dom'
 
 export interface AttestationBadgeProps {
   hasAttestationFile: boolean
+  placement?: Placement
 }
 
 export const AttestationBadge: React.FC<AttestationBadgeProps> = ({
   hasAttestationFile,
+  placement,
 }) => {
   const [showTooltip, setShowTooltip] = useState<boolean>(false)
 
   const { x, y, refs, strategy } = useFloating({
-    placement: 'top',
+    placement: placement ?? 'top',
   })
 
   if (!hasAttestationFile) {
@@ -22,7 +24,7 @@ export const AttestationBadge: React.FC<AttestationBadgeProps> = ({
     <>
       <span
         ref={refs.setReference}
-        className="text-blue-600 font-bold text-lg cursor-help"
+        className="fill-white font-bold w-5 h-5 text-center rounded-full cursor-help"
         aria-label="Attested release provenance"
         role="img"
         onMouseEnter={() => setShowTooltip(true)}
@@ -30,7 +32,17 @@ export const AttestationBadge: React.FC<AttestationBadgeProps> = ({
         onFocus={() => setShowTooltip(true)}
         onBlur={() => setShowTooltip(false)}
       >
-        ✓
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 22 22"
+          height="100%"
+          width="100%"
+        >
+          <path
+            d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.75-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.54-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.274 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"
+            fill="#004aff"
+          />
+        </svg>
       </span>
       {showTooltip && (
         <div

--- a/components/CopyCode.tsx
+++ b/components/CopyCode.tsx
@@ -2,6 +2,7 @@ import { faCopy } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useFloating } from '@floating-ui/react-dom'
 import React, { useState } from 'react'
+import { faClone } from '@fortawesome/free-solid-svg-icons'
 
 export interface CopyCodeProps {
   code: string
@@ -26,13 +27,13 @@ export const CopyCode: React.FC<CopyCodeProps> = ({ code }) => {
     <>
       <button
         ref={refs.setReference}
-        className="w-full flex justify-between items-center p-2 my-4 rounded bg-gray-200 group hover:bg-gray-100 border hover:border-gray-800 cursor-pointer"
+        className="w-full flex justify-between items-center pt-3 pb-3 pl-4 pr-4 my-4  border-2 border-green-800 rounded-full group bg-green-700 bg-opacity-5 hover:bg-opacity-20 hover:border-bzl-green cursor-pointer"
         title="Copy MODULE.bazel snippet to clipboard"
         onClick={handleClickCopy}
       >
         <code>{code}</code>
-        <div className="text-gray-500 group-hover:text-black">
-          <FontAwesomeIcon icon={faCopy} />
+        <div className="text-green-700 group-hover:text-bzl-green group-hover:scale-110">
+          <FontAwesomeIcon icon={faClone} />
         </div>
       </button>
       {

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -7,7 +7,7 @@ import { Footer } from '../../components/Footer'
 import { listModuleNames, Metadata } from '../../data/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
-import { faEnvelope } from '@fortawesome/free-regular-svg-icons'
+import { faEnvelope, faStar } from '@fortawesome/free-regular-svg-icons'
 import { CopyCode } from '../../components/CopyCode'
 import { AttestationBadge } from '../../components/AttestationBadge'
 import React, { useEffect, useState } from 'react'
@@ -16,7 +16,7 @@ import {
   VersionInfo,
 } from '../../data/moduleStaticProps'
 import { formatDistance, parseISO } from 'date-fns'
-import { faGlobe } from '@fortawesome/free-solid-svg-icons'
+import { faGlobe, faScaleBalanced } from '@fortawesome/free-solid-svg-icons'
 
 interface ModulePageProps {
   metadata: Metadata
@@ -59,7 +59,12 @@ const ModulePage: NextPage<ModulePageProps> = ({
     selectedVersion
   )
 
-  const repoDescription = useGithubRepoDescription(firstGithubRepository)
+  const {
+    description: repoDescription,
+    license: repoLicense,
+    topics: repoTopics,
+    stargazers: repoStargazers,
+  } = useGithubMetadata(firstGithubRepository)
 
   const isQualifiedForShowAllVersions =
     versionInfos.length > NUM_VERSIONS_ON_PAGE_LOAD
@@ -108,7 +113,19 @@ const ModulePage: NextPage<ModulePageProps> = ({
         <div className="max-w-4xl w-4xl mx-auto mt-8">
           <div className="border rounded p-4 divide-y">
             <div>
-              <span role="heading" aria-level={1} className="text-3xl">
+              {versionInfo.hasAttestationFile && (
+                <span className="w-7 h-7 inline-block align-middle mr-1">
+                  <AttestationBadge
+                    hasAttestationFile={true}
+                    placement="bottom-start"
+                  />
+                </span>
+              )}
+              <span
+                role="heading"
+                aria-level={1}
+                className="text-3xl align-middle"
+              >
                 {module}
               </span>
               <span className="text-lg ml-2">{selectedVersion}</span>
@@ -347,65 +364,109 @@ const ModulePage: NextPage<ModulePageProps> = ({
                 </div>
               </div>
               <div id="metadata" className="sm:pl-2 basis-8 md:basis-[12rem]">
-                <h2 className="text-2xl font-bold mt-4 mb-2">Metadata</h2>
+                <h2 className="text-2xl font-bold mt-4 mb-2">About</h2>
                 <div>
                   {repoDescription && (
-                    <div className="mb-3">
-                      <p className="text-sm">{repoDescription}</p>
+                    <div className="mb-2">
+                      <p className="text-md">{repoDescription}</p>
                     </div>
                   )}
-                  {metadata.homepage !== githubLink ? (
-                    <a
-                      href={metadata.homepage}
-                      className="text-link-color hover:text-link-color-hover"
-                      title={metadata.homepage}
-                    >
-                      <FontAwesomeIcon icon={faGlobe} className="mr-1" />
-                      Homepage
-                    </a>
-                  ) : null}
+                  <div className="space-y-1">
+                    {repoTopics && (
+                      <div className="mb-4 mt-4">
+                        {repoTopics.map((topic) => {
+                          return (
+                            <span
+                              className="rounded-xl pl-3 pr-3 pt-1 pb-1 font-semibold mr-1 text-sm text-[#0b713b] bg-[#0b713b1a]"
+                              key={topic}
+                            >
+                              {topic}
+                            </span>
+                          )
+                        })}
+                      </div>
+                    )}
+
+                    <div className="text-black">
+                      <FontAwesomeIcon
+                        className="mr-1 min-w-[30px]"
+                        icon={faStar}
+                      />
+                      {repoStargazers} Stars
+                    </div>
+
+                    {repoLicense && (
+                      <a
+                        href={repoLicense.url}
+                        className="block text-black hover:text-link-color-hover"
+                        title={repoLicense.spdx_id}
+                      >
+                        <FontAwesomeIcon
+                          className="mr-1 min-w-[30px]"
+                          icon={faScaleBalanced}
+                        />
+                        {repoLicense.name}
+                      </a>
+                    )}
+
+                    {metadata.homepage !== githubLink ? (
+                      <a
+                        href={metadata.homepage}
+                        className="text-black hover:text-link-color-hover"
+                        title={metadata.homepage}
+                      >
+                        <FontAwesomeIcon
+                          icon={faGlobe}
+                          className="mr-1 min-w-[30px]"
+                        />
+                        Homepage
+                      </a>
+                    ) : null}
+                    {githubLink && (
+                      <div>
+                        <a
+                          href={githubLink}
+                          className="text-black hover:text-link-color-hover"
+                          title={githubLink}
+                        >
+                          <FontAwesomeIcon
+                            icon={faGithub}
+                            className="mr-1 min-w-[30px]"
+                          />
+                          GitHub repository
+                        </a>
+                      </div>
+                    )}
+                  </div>
                 </div>
-                {githubLink && (
-                  <div>
-                    <a
-                      href={githubLink}
-                      className="text-link-color hover:text-link-color-hover"
-                      title={githubLink}
-                    >
-                      <FontAwesomeIcon icon={faGithub} className="mr-1" />
-                      GitHub repository
-                    </a>
-                  </div>
-                )}
+
+                <h2 className="text-2xl font-bold mt-4 mb-2">Maintainers</h2>
                 <div>
-                  <h3 className="font-bold text-xl mt-2">Maintainers</h3>
-                  <div>
-                    <ul>
-                      {metadata.maintainers?.map(({ name, email, github }) => (
-                        <li key={name}>
-                          <span className="flex">
-                            {email && (
-                              <a
-                                className="text-link-color hover:text-link-color-hover cursor-pointer mr-1"
-                                href={`mailto:${email}`}
-                              >
-                                <FontAwesomeIcon icon={faEnvelope} />
-                              </a>
-                            )}
-                            {github && (
-                              <a
-                                className="text-link-color hover:text-link-color-hover cursor-pointer mr-1"
-                                href={`https://github.com/${github}`}
-                              >
-                                <FontAwesomeIcon icon={faGithub} />
-                              </a>
-                            )}
-                            {name}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
+                  <ul>
+                    {metadata.maintainers?.map(({ name, email, github }) => (
+                      <li key={name} className="ml-1.5">
+                        <span className="flex">
+                          {email && (
+                            <a
+                              className="text-black hover:text-green-800 hover:scale-125 cursor-pointer mr-1"
+                              href={`mailto:${email}`}
+                            >
+                              <FontAwesomeIcon icon={faEnvelope} />
+                            </a>
+                          )}
+                          {github && (
+                            <a
+                              className="text-black hover:text-green-600 hover:scale-125 cursor-pointer mr-1"
+                              href={`https://github.com/${github}`}
+                            >
+                              <FontAwesomeIcon icon={faGithub} />
+                            </a>
+                          )}
+                          {name}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               </div>
             </div>
@@ -543,11 +604,14 @@ const useDetectReleaseFormatViaGithubApi = (
   return releaseTagFormat
 }
 
-const useGithubRepoDescription = (
-  metadataRepository: string | undefined
-): string | undefined => {
+const useGithubMetadata = (metadataRepository: string | undefined) => {
   const githubOwnerAndRepo = metadataRepository?.replace('github:', '')
   const [description, setDescription] = useState<string | undefined>(undefined)
+  const [license, setLicense] = useState<
+    { spdx_id: string; name: string; url: string } | undefined
+  >()
+  const [topics, setTopics] = useState<string[]>([])
+  const [stargazers, setStargazers] = useState<number>(0)
 
   useEffect(() => {
     const fetchRepoDescription = async () => {
@@ -570,7 +634,15 @@ const useGithubRepoDescription = (
 
         if (response.ok) {
           const repoData = await response.json()
+          setStargazers(repoData.stargazers_count)
           setDescription(repoData.description)
+          if (repoData.license) {
+            setLicense(repoData.license)
+          }
+
+          if (Array.isArray(repoData.topics)) {
+            setTopics(repoData.topics)
+          }
         }
       } catch (error) {
         console.error('Failed to fetch repository description:', error)
@@ -580,7 +652,12 @@ const useGithubRepoDescription = (
     fetchRepoDescription()
   }, [githubOwnerAndRepo])
 
-  return description
+  return {
+    description,
+    license,
+    topics,
+    stargazers,
+  }
 }
 
 export default ModulePage

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -112,9 +112,9 @@ const ModulePage: NextPage<ModulePageProps> = ({
       <main>
         <div className="max-w-4xl w-4xl mx-auto mt-8">
           <div className="border rounded p-4 divide-y">
-            <div>
+            <div className="flex items-center gap-1">
               {versionInfo.hasAttestationFile && (
-                <span className="w-7 h-7 inline-block align-middle mr-1">
+                <span className="w-7 h-7 inline-block">
                   <AttestationBadge
                     hasAttestationFile={true}
                     placement="bottom-start"
@@ -124,7 +124,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
               <span
                 role="heading"
                 aria-level={1}
-                className="text-3xl align-middle"
+                className="text-3xl translate-y-[-3px]"
               >
                 {module}
               </span>
@@ -373,11 +373,11 @@ const ModulePage: NextPage<ModulePageProps> = ({
                   )}
                   <div className="space-y-1">
                     {repoTopics && (
-                      <div className="mb-4 mt-4">
+                      <div className="mb-4 mt-4 flex flex-row flex-wrap gap-1">
                         {repoTopics.map((topic) => {
                           return (
                             <span
-                              className="rounded-xl pl-3 pr-3 pt-1 pb-1 font-semibold mr-1 text-sm text-[#0b713b] bg-[#0b713b1a]"
+                              className="rounded-xl pl-3 pr-3 pt-0.5 pb-0.5 font-semibold mr-1 text-sm text-[#0b713b] bg-[#0b713b1a]"
                               key={topic}
                             >
                               {topic}
@@ -387,18 +387,34 @@ const ModulePage: NextPage<ModulePageProps> = ({
                       </div>
                     )}
 
-                    <div className="text-black">
-                      <FontAwesomeIcon
-                        className="mr-1 min-w-[30px]"
-                        icon={faStar}
-                      />
-                      {repoStargazers} Stars
-                    </div>
+                    {metadata.homepage !== githubLink ? (
+                      <a
+                        href={metadata.homepage}
+                        className="block text-link-color hover:text-link-color-hover"
+                        title={metadata.homepage}
+                      >
+                        <FontAwesomeIcon
+                          icon={faGlobe}
+                          className="mr-1 min-w-[30px]"
+                        />
+                        Homepage
+                      </a>
+                    ) : null}
+
+                    {repoStargazers && (
+                      <div className="text-black">
+                        <FontAwesomeIcon
+                          className="mr-1 min-w-[30px]"
+                          icon={faStar}
+                        />
+                        {repoStargazers} Stars
+                      </div>
+                    )}
 
                     {repoLicense && (
                       <a
                         href={repoLicense.url}
-                        className="block text-black hover:text-link-color-hover"
+                        className="block text-link-color hover:text-link-color-hover cursor-pointer"
                         title={repoLicense.spdx_id}
                       >
                         <FontAwesomeIcon
@@ -409,24 +425,11 @@ const ModulePage: NextPage<ModulePageProps> = ({
                       </a>
                     )}
 
-                    {metadata.homepage !== githubLink ? (
-                      <a
-                        href={metadata.homepage}
-                        className="text-black hover:text-link-color-hover"
-                        title={metadata.homepage}
-                      >
-                        <FontAwesomeIcon
-                          icon={faGlobe}
-                          className="mr-1 min-w-[30px]"
-                        />
-                        Homepage
-                      </a>
-                    ) : null}
                     {githubLink && (
                       <div>
                         <a
                           href={githubLink}
-                          className="text-black hover:text-link-color-hover"
+                          className="text-link-color hover:text-link-color-hover"
                           title={githubLink}
                         >
                           <FontAwesomeIcon
@@ -611,7 +614,7 @@ const useGithubMetadata = (metadataRepository: string | undefined) => {
     { spdx_id: string; name: string; url: string } | undefined
   >()
   const [topics, setTopics] = useState<string[]>([])
-  const [stargazers, setStargazers] = useState<number>(0)
+  const [stargazers, setStargazers] = useState<number | undefined>(undefined)
 
   useEffect(() => {
     const fetchRepoDescription = async () => {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
+
 html,
 body {
   padding: 0;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,8 +8,8 @@ module.exports = {
     extend: {
       colors: {
         'bzl-green': '#0C713A',
-        'link-color': '#00AC5B',
-        'link-color-hover': '#007940',
+        'link-color': '#0C713A',
+        'link-color-hover': '#00AC5B',
       },
     },
   },


### PR DESCRIPTION
Main section 
- Add contrast copy code section
- Show the attestation badge right next to module name if the selected version has it 
- Make attestation badge noticeable 

About section 
- Add License information from repo 
- Add star information from repo
- Add topics from repo
- Rename Metadata to About 
- Add contrast to links in About section and only change to green on hover and align icons vertically
- Pop Github and Email icons for maintainers on hover

Overall: 
<img width="1015" alt="Screenshot 2025-06-20 at 4 36 53 PM" src="https://github.com/user-attachments/assets/ab66a257-023e-4cac-9b6d-85a107a6a059" />

Hover:
<img width="168" alt="Screenshot 2025-06-20 at 12 37 59 PM" src="https://github.com/user-attachments/assets/192b7316-5998-41ca-9520-ecdeb7f78056" />

Hover:
<img width="221" alt="Screenshot 2025-06-20 at 12 38 33 PM" src="https://github.com/user-attachments/assets/aae774d4-7989-48f1-ae1b-4eac4afb7018" />
