### PR TITLE
feat: render stardocs

### DIFF
--- a/components/Stardoc.tsx
+++ b/components/Stardoc.tsx
@@ -1,12 +1,47 @@
-import React from 'react'
+import React, { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { tomorrow } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 import { StardocModuleInfo } from '../data/stardoc'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faLink, faCopy, faCheck } from '@fortawesome/free-solid-svg-icons'
 
 interface StardocRendererProps {
   stardoc: StardocModuleInfo
   fileName?: string
+}
+
+// Helper function to generate anchor IDs
+const generateAnchorId = (type: string, name: string): string => {
+  return `${type}-${name.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase()}`
+}
+
+// Copy link component
+const CopyLinkButton: React.FC<{ anchorId: string }> = ({ anchorId }) => {
+  const [copied, setCopied] = useState(false)
+
+  const copyToClipboard = async () => {
+    const url = `${window.location.origin}${window.location.pathname}#${anchorId}`
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy link:', err)
+    }
+  }
+
+  return (
+    <button
+      onClick={copyToClipboard}
+      className="ml-2 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+      title="Copy link to this section"
+    >
+      <FontAwesomeIcon icon={copied ? faCheck : faCopy} className="w-3 h-3" />
+    </button>
+  )
 }
 
 // Shared markdown components with syntax highlighting
@@ -43,15 +78,67 @@ const markdownComponents = {
       </code>
     )
   },
-  a: ({ href, children }: any) => (
-    <a
-      href={href}
-      className="text-blue-600 hover:text-blue-800 underline"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+  a: ({ href, children }: any) => {
+    // Check if it's an external link
+    const isExternal =
+      href && (href.startsWith('http') || href.startsWith('//'))
+
+    return (
+      <a
+        href={href}
+        className="text-blue-600 hover:text-blue-800 underline"
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+      >
+        {children}
+      </a>
+    )
+  },
+  // Enhanced paragraph component to handle automatic link detection
+  p: ({ children }: any) => <p className="mb-2 leading-relaxed">{children}</p>,
+  // Enhanced list components
+  ul: ({ children }: any) => (
+    <ul className="list-disc list-inside space-y-1 my-2 ml-4">{children}</ul>
+  ),
+  ol: ({ children }: any) => (
+    <ol className="list-decimal list-inside space-y-1 my-2 ml-4">{children}</ol>
+  ),
+  // Enhanced heading components
+  h1: ({ children }: any) => (
+    <h1 className="text-2xl font-bold mt-6 mb-3 text-gray-900">{children}</h1>
+  ),
+  h2: ({ children }: any) => (
+    <h2 className="text-xl font-semibold mt-5 mb-2 text-gray-900">
       {children}
-    </a>
+    </h2>
+  ),
+  h3: ({ children }: any) => (
+    <h3 className="text-lg font-medium mt-4 mb-2 text-gray-900">{children}</h3>
+  ),
+  h4: ({ children }: any) => (
+    <h4 className="text-base font-medium mt-3 mb-2 text-gray-900">
+      {children}
+    </h4>
+  ),
+  // Blockquote styling
+  blockquote: ({ children }: any) => (
+    <blockquote className="border-l-4 border-gray-300 pl-4 italic text-gray-700 my-4">
+      {children}
+    </blockquote>
+  ),
+  // Table styling
+  table: ({ children }: any) => (
+    <div className="overflow-x-auto my-4">
+      <table className="min-w-full border border-gray-300">{children}</table>
+    </div>
+  ),
+  th: ({ children }: any) => (
+    <th className="border border-gray-300 px-4 py-2 bg-gray-100 font-semibold text-left">
+      {children}
+    </th>
+  ),
+  td: ({ children }: any) => (
+    <td className="border border-gray-300 px-4 py-2">{children}</td>
   ),
 }
 
@@ -86,47 +173,60 @@ export const StardocRenderer: React.FC<StardocRendererProps> = ({
       {/* Functions */}
       {stardoc.funcInfo && stardoc.funcInfo.length > 0 && (
         <div className="mb-6">
-          <h4 className="text-lg font-medium text-gray-900 mb-3">Functions</h4>
+          <h4 className="text-lg font-medium text-gray-900 mb-3">
+            Functions & Macros
+          </h4>
           <div className="space-y-4">
-            {stardoc.funcInfo.map((func, funcIndex) => (
-              <div key={funcIndex} className="border-l-4 border-blue-500 pl-4">
-                <div className="flex items-center gap-2 mb-2">
-                  <code className="bg-blue-100 text-blue-800 px-3 py-1 rounded text-sm font-mono">
-                    {func.functionName}
-                  </code>
-                </div>
-                {func.docString && (
-                  <div className="prose prose-sm max-w-none">
-                    <ReactMarkdown components={markdownComponents}>
-                      {func.docString}
-                    </ReactMarkdown>
+            {stardoc.funcInfo.map((func, funcIndex) => {
+              const anchorId = generateAnchorId('function', func.functionName)
+              return (
+                <div
+                  key={funcIndex}
+                  id={anchorId}
+                  className="border-l-4 border-blue-500 pl-4 scroll-mt-20"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <code className="bg-blue-100 text-blue-800 px-3 py-1 rounded text-sm font-mono">
+                      {func.functionName}
+                    </code>
+                    <CopyLinkButton anchorId={anchorId} />
                   </div>
-                )}
+                  {func.docString && (
+                    <div className="prose prose-sm max-w-none">
+                      <ReactMarkdown
+                        components={markdownComponents}
+                        remarkPlugins={[remarkGfm, remarkBreaks]}
+                      >
+                        {func.docString}
+                      </ReactMarkdown>
+                    </div>
+                  )}
 
-                {/* Function parameters */}
-                {func.parameter && func.parameter.length > 0 && (
-                  <div className="mt-3">
-                    <h5 className="text-sm font-medium text-gray-700 mb-2">
-                      Parameters
-                    </h5>
-                    <ul className="space-y-2">
-                      {func.parameter.map((param, paramIndex) => (
-                        <li key={paramIndex} className="text-sm">
-                          <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
-                            {param.name}
-                          </code>
-                          {param.docString && (
-                            <span className="ml-2 text-gray-600">
-                              - {param.docString}
-                            </span>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-              </div>
-            ))}
+                  {/* Function parameters */}
+                  {func.parameter && func.parameter.length > 0 && (
+                    <div className="mt-3">
+                      <h5 className="text-sm font-medium text-gray-700 mb-2">
+                        Parameters
+                      </h5>
+                      <ul className="space-y-2">
+                        {func.parameter.map((param, paramIndex) => (
+                          <li key={paramIndex} className="text-sm">
+                            <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
+                              {param.name}
+                            </code>
+                            {param.docString && (
+                              <span className="ml-2 text-gray-600">
+                                - {param.docString}
+                              </span>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
           </div>
         </div>
       )}
@@ -136,45 +236,56 @@ export const StardocRenderer: React.FC<StardocRendererProps> = ({
         <div className="mb-6">
           <h4 className="text-lg font-medium text-gray-900 mb-3">Rules</h4>
           <div className="space-y-4">
-            {stardoc.ruleInfo.map((rule, ruleIndex) => (
-              <div key={ruleIndex} className="border-l-4 border-green-500 pl-4">
-                <div className="flex items-center gap-2 mb-2">
-                  <code className="bg-green-100 text-green-800 px-3 py-1 rounded text-sm font-mono">
-                    {rule.ruleName}
-                  </code>
-                </div>
-                {rule.docString && (
-                  <div className="prose prose-sm max-w-none">
-                    <ReactMarkdown components={markdownComponents}>
-                      {rule.docString}
-                    </ReactMarkdown>
+            {stardoc.ruleInfo.map((rule, ruleIndex) => {
+              const anchorId = generateAnchorId('rule', rule.ruleName)
+              return (
+                <div
+                  key={ruleIndex}
+                  id={anchorId}
+                  className="border-l-4 border-green-500 pl-4 scroll-mt-20"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <code className="bg-green-100 text-green-800 px-3 py-1 rounded text-sm font-mono">
+                      {rule.ruleName}
+                    </code>
+                    <CopyLinkButton anchorId={anchorId} />
                   </div>
-                )}
+                  {rule.docString && (
+                    <div className="prose prose-sm max-w-none">
+                      <ReactMarkdown
+                        components={markdownComponents}
+                        remarkPlugins={[remarkGfm, remarkBreaks]}
+                      >
+                        {rule.docString}
+                      </ReactMarkdown>
+                    </div>
+                  )}
 
-                {/* Rule attributes */}
-                {rule.attribute && rule.attribute.length > 0 && (
-                  <div className="mt-3">
-                    <h5 className="text-sm font-medium text-gray-700 mb-2">
-                      Attributes
-                    </h5>
-                    <ul className="space-y-2">
-                      {rule.attribute.map((attr, attrIndex) => (
-                        <li key={attrIndex} className="text-sm">
-                          <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
-                            {attr.name}
-                          </code>
-                          {attr.docString && (
-                            <span className="ml-2 text-gray-600">
-                              - {attr.docString}
-                            </span>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-              </div>
-            ))}
+                  {/* Rule attributes */}
+                  {rule.attribute && rule.attribute.length > 0 && (
+                    <div className="mt-3">
+                      <h5 className="text-sm font-medium text-gray-700 mb-2">
+                        Attributes
+                      </h5>
+                      <ul className="space-y-2">
+                        {rule.attribute.map((attr, attrIndex) => (
+                          <li key={attrIndex} className="text-sm">
+                            <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
+                              {attr.name}
+                            </code>
+                            {attr.docString && (
+                              <span className="ml-2 text-gray-600">
+                                - {attr.docString}
+                              </span>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
           </div>
         </div>
       )}
@@ -184,48 +295,59 @@ export const StardocRenderer: React.FC<StardocRendererProps> = ({
         <div className="mb-6">
           <h4 className="text-lg font-medium text-gray-900 mb-3">Providers</h4>
           <div className="space-y-4">
-            {stardoc.providerInfo.map((provider, providerIndex) => (
-              <div
-                key={providerIndex}
-                className="border-l-4 border-purple-500 pl-4"
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  <code className="bg-purple-100 text-purple-800 px-3 py-1 rounded text-sm font-mono">
-                    {provider.providerName}
-                  </code>
-                </div>
-                {provider.docString && (
-                  <div className="prose prose-sm max-w-none">
-                    <ReactMarkdown components={markdownComponents}>
-                      {provider.docString}
-                    </ReactMarkdown>
+            {stardoc.providerInfo.map((provider, providerIndex) => {
+              const anchorId = generateAnchorId(
+                'provider',
+                provider.providerName
+              )
+              return (
+                <div
+                  key={providerIndex}
+                  id={anchorId}
+                  className="border-l-4 border-purple-500 pl-4 scroll-mt-20"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <code className="bg-purple-100 text-purple-800 px-3 py-1 rounded text-sm font-mono">
+                      {provider.providerName}
+                    </code>
+                    <CopyLinkButton anchorId={anchorId} />
                   </div>
-                )}
+                  {provider.docString && (
+                    <div className="prose prose-sm max-w-none">
+                      <ReactMarkdown
+                        components={markdownComponents}
+                        remarkPlugins={[remarkGfm, remarkBreaks]}
+                      >
+                        {provider.docString}
+                      </ReactMarkdown>
+                    </div>
+                  )}
 
-                {/* Provider fields */}
-                {provider.fieldInfo && provider.fieldInfo.length > 0 && (
-                  <div className="mt-3">
-                    <h5 className="text-sm font-medium text-gray-700 mb-2">
-                      Fields
-                    </h5>
-                    <ul className="space-y-2">
-                      {provider.fieldInfo.map((field, fieldIndex) => (
-                        <li key={fieldIndex} className="text-sm">
-                          <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
-                            {field.name}
-                          </code>
-                          {field.docString && (
-                            <span className="ml-2 text-gray-600">
-                              - {field.docString}
-                            </span>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-              </div>
-            ))}
+                  {/* Provider fields */}
+                  {provider.fieldInfo && provider.fieldInfo.length > 0 && (
+                    <div className="mt-3">
+                      <h5 className="text-sm font-medium text-gray-700 mb-2">
+                        Fields
+                      </h5>
+                      <ul className="space-y-2">
+                        {provider.fieldInfo.map((field, fieldIndex) => (
+                          <li key={fieldIndex} className="text-sm">
+                            <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
+                              {field.name}
+                            </code>
+                            {field.docString && (
+                              <span className="ml-2 text-gray-600">
+                                - {field.docString}
+                              </span>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
           </div>
         </div>
       )}
@@ -235,25 +357,33 @@ export const StardocRenderer: React.FC<StardocRendererProps> = ({
         <div className="mb-6">
           <h4 className="text-lg font-medium text-gray-900 mb-3">Aspects</h4>
           <div className="space-y-4">
-            {stardoc.aspectInfo.map((aspect, aspectIndex) => (
-              <div
-                key={aspectIndex}
-                className="border-l-4 border-orange-500 pl-4"
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  <code className="bg-orange-100 text-orange-800 px-3 py-1 rounded text-sm font-mono">
-                    {aspect.aspectName}
-                  </code>
-                </div>
-                {aspect.docString && (
-                  <div className="prose prose-sm max-w-none">
-                    <ReactMarkdown components={markdownComponents}>
-                      {aspect.docString}
-                    </ReactMarkdown>
+            {stardoc.aspectInfo.map((aspect, aspectIndex) => {
+              const anchorId = generateAnchorId('aspect', aspect.aspectName)
+              return (
+                <div
+                  key={aspectIndex}
+                  id={anchorId}
+                  className="border-l-4 border-orange-500 pl-4 scroll-mt-20"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <code className="bg-orange-100 text-orange-800 px-3 py-1 rounded text-sm font-mono">
+                      {aspect.aspectName}
+                    </code>
+                    <CopyLinkButton anchorId={anchorId} />
                   </div>
-                )}
-              </div>
-            ))}
+                  {aspect.docString && (
+                    <div className="prose prose-sm max-w-none">
+                      <ReactMarkdown
+                        components={markdownComponents}
+                        remarkPlugins={[remarkGfm, remarkBreaks]}
+                      >
+                        {aspect.docString}
+                      </ReactMarkdown>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
           </div>
         </div>
       )}

--- a/components/Stardoc.tsx
+++ b/components/Stardoc.tsx
@@ -1,0 +1,262 @@
+import React from 'react'
+import ReactMarkdown from 'react-markdown'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { tomorrow } from 'react-syntax-highlighter/dist/cjs/styles/prism'
+import { StardocModuleInfo } from '../data/stardoc'
+
+interface StardocRendererProps {
+  stardoc: StardocModuleInfo
+  fileName?: string
+}
+
+// Shared markdown components with syntax highlighting
+const markdownComponents = {
+  code: ({ node, inline, className, children, ...props }: any) => {
+    const match = /language-(\w+)/.exec(className || '')
+    let language = match ? match[1] : ''
+
+    // Map common Bazel/Starlark language aliases
+    if (language === 'starlark' || language === 'bazel' || language === 'bzl') {
+      language = 'python' // Use Python highlighting for Starlark
+    }
+
+    if (!inline && language) {
+      return (
+        <SyntaxHighlighter
+          style={tomorrow}
+          language={language}
+          PreTag="div"
+          className="rounded-md"
+          {...props}
+        >
+          {String(children).replace(/\n$/, '')}
+        </SyntaxHighlighter>
+      )
+    }
+
+    return (
+      <code
+        className="bg-gray-100 px-1 py-0.5 rounded text-sm font-mono"
+        {...props}
+      >
+        {children}
+      </code>
+    )
+  },
+  a: ({ href, children }: any) => (
+    <a
+      href={href}
+      className="text-blue-600 hover:text-blue-800 underline"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </a>
+  ),
+}
+
+export const StardocRenderer: React.FC<StardocRendererProps> = ({
+  stardoc,
+  fileName,
+}) => {
+  if (!stardoc) {
+    return (
+      <div className="p-4 border border-gray-200 rounded-lg bg-gray-50">
+        <p className="text-gray-500">No API documentation available</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-4">
+      {/* Module-level documentation */}
+      {stardoc.moduleDocstring && (
+        <div className="mb-6">
+          <h4 className="text-lg font-medium font-mono text-gray-900 mb-3">
+            {stardoc.file}
+          </h4>
+          <div className="prose prose-sm max-w-none">
+            <ReactMarkdown components={markdownComponents}>
+              {stardoc.moduleDocstring}
+            </ReactMarkdown>
+          </div>
+        </div>
+      )}
+
+      {/* Functions */}
+      {stardoc.funcInfo && stardoc.funcInfo.length > 0 && (
+        <div className="mb-6">
+          <h4 className="text-lg font-medium text-gray-900 mb-3">Functions</h4>
+          <div className="space-y-4">
+            {stardoc.funcInfo.map((func, funcIndex) => (
+              <div key={funcIndex} className="border-l-4 border-blue-500 pl-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <code className="bg-blue-100 text-blue-800 px-3 py-1 rounded text-sm font-mono">
+                    {func.functionName}
+                  </code>
+                </div>
+                {func.docString && (
+                  <div className="prose prose-sm max-w-none">
+                    <ReactMarkdown components={markdownComponents}>
+                      {func.docString}
+                    </ReactMarkdown>
+                  </div>
+                )}
+
+                {/* Function parameters */}
+                {func.parameter && func.parameter.length > 0 && (
+                  <div className="mt-3">
+                    <h5 className="text-sm font-medium text-gray-700 mb-2">
+                      Parameters
+                    </h5>
+                    <ul className="space-y-2">
+                      {func.parameter.map((param, paramIndex) => (
+                        <li key={paramIndex} className="text-sm">
+                          <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
+                            {param.name}
+                          </code>
+                          {param.docString && (
+                            <span className="ml-2 text-gray-600">
+                              - {param.docString}
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Rules */}
+      {stardoc.ruleInfo && stardoc.ruleInfo.length > 0 && (
+        <div className="mb-6">
+          <h4 className="text-lg font-medium text-gray-900 mb-3">Rules</h4>
+          <div className="space-y-4">
+            {stardoc.ruleInfo.map((rule, ruleIndex) => (
+              <div key={ruleIndex} className="border-l-4 border-green-500 pl-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <code className="bg-green-100 text-green-800 px-3 py-1 rounded text-sm font-mono">
+                    {rule.ruleName}
+                  </code>
+                </div>
+                {rule.docString && (
+                  <div className="prose prose-sm max-w-none">
+                    <ReactMarkdown components={markdownComponents}>
+                      {rule.docString}
+                    </ReactMarkdown>
+                  </div>
+                )}
+
+                {/* Rule attributes */}
+                {rule.attribute && rule.attribute.length > 0 && (
+                  <div className="mt-3">
+                    <h5 className="text-sm font-medium text-gray-700 mb-2">
+                      Attributes
+                    </h5>
+                    <ul className="space-y-2">
+                      {rule.attribute.map((attr, attrIndex) => (
+                        <li key={attrIndex} className="text-sm">
+                          <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
+                            {attr.name}
+                          </code>
+                          {attr.docString && (
+                            <span className="ml-2 text-gray-600">
+                              - {attr.docString}
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Providers */}
+      {stardoc.providerInfo && stardoc.providerInfo.length > 0 && (
+        <div className="mb-6">
+          <h4 className="text-lg font-medium text-gray-900 mb-3">Providers</h4>
+          <div className="space-y-4">
+            {stardoc.providerInfo.map((provider, providerIndex) => (
+              <div
+                key={providerIndex}
+                className="border-l-4 border-purple-500 pl-4"
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <code className="bg-purple-100 text-purple-800 px-3 py-1 rounded text-sm font-mono">
+                    {provider.providerName}
+                  </code>
+                </div>
+                {provider.docString && (
+                  <div className="prose prose-sm max-w-none">
+                    <ReactMarkdown components={markdownComponents}>
+                      {provider.docString}
+                    </ReactMarkdown>
+                  </div>
+                )}
+
+                {/* Provider fields */}
+                {provider.fieldInfo && provider.fieldInfo.length > 0 && (
+                  <div className="mt-3">
+                    <h5 className="text-sm font-medium text-gray-700 mb-2">
+                      Fields
+                    </h5>
+                    <ul className="space-y-2">
+                      {provider.fieldInfo.map((field, fieldIndex) => (
+                        <li key={fieldIndex} className="text-sm">
+                          <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
+                            {field.name}
+                          </code>
+                          {field.docString && (
+                            <span className="ml-2 text-gray-600">
+                              - {field.docString}
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Aspects */}
+      {stardoc.aspectInfo && stardoc.aspectInfo.length > 0 && (
+        <div className="mb-6">
+          <h4 className="text-lg font-medium text-gray-900 mb-3">Aspects</h4>
+          <div className="space-y-4">
+            {stardoc.aspectInfo.map((aspect, aspectIndex) => (
+              <div
+                key={aspectIndex}
+                className="border-l-4 border-orange-500 pl-4"
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <code className="bg-orange-100 text-orange-800 px-3 py-1 rounded text-sm font-mono">
+                    {aspect.aspectName}
+                  </code>
+                </div>
+                {aspect.docString && (
+                  <div className="prose prose-sm max-w-none">
+                    <ReactMarkdown components={markdownComponents}>
+                      {aspect.docString}
+                    </ReactMarkdown>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/Stardoc.tsx
+++ b/components/Stardoc.tsx
@@ -15,7 +15,16 @@ interface StardocRendererProps {
 
 // Helper function to generate anchor IDs
 const generateAnchorId = (type: string, name: string): string => {
-  return `${type}-${name.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase()}`
+  // Strip leading slashes and clean the name
+  const cleanName = name
+    .replace(/^\/+/, '')
+    .replace(/[^a-zA-Z0-9-_]/g, '-')
+    .toLowerCase()
+
+  if (type === 'file') {
+    return cleanName
+  }
+  return `${type}-${cleanName}`
 }
 
 // Copy link component
@@ -159,11 +168,27 @@ export const StardocRenderer: React.FC<StardocRendererProps> = ({
       {/* Module-level documentation */}
       {stardoc.moduleDocstring && (
         <div className="mb-6">
-          <h4 className="text-lg font-medium font-mono text-gray-900 mb-3">
-            {stardoc.file}
-          </h4>
+          {(() => {
+            const fileAnchorId = generateAnchorId(
+              'file',
+              stardoc.file || 'module'
+            )
+            return (
+              <div id={fileAnchorId} className="scroll-mt-20">
+                <div className="flex items-center gap-2 mb-3">
+                  <h4 className="text-lg font-medium font-mono text-gray-900">
+                    {stardoc.file}
+                  </h4>
+                  <CopyLinkButton anchorId={fileAnchorId} />
+                </div>
+              </div>
+            )
+          })()}
           <div className="prose prose-sm max-w-none">
-            <ReactMarkdown components={markdownComponents}>
+            <ReactMarkdown
+              components={markdownComponents}
+              remarkPlugins={[remarkGfm, remarkBreaks]}
+            >
               {stardoc.moduleDocstring}
             </ReactMarkdown>
           </div>

--- a/components/Stardoc.tsx
+++ b/components/Stardoc.tsx
@@ -6,11 +6,10 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { tomorrow } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 import { StardocModuleInfo } from '../data/stardoc'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faLink, faCopy, faCheck } from '@fortawesome/free-solid-svg-icons'
+import { faCopy, faCheck } from '@fortawesome/free-solid-svg-icons'
 
 interface StardocRendererProps {
   stardoc: StardocModuleInfo
-  fileName?: string
 }
 
 // Helper function to generate anchor IDs
@@ -153,7 +152,6 @@ const markdownComponents = {
 
 export const StardocRenderer: React.FC<StardocRendererProps> = ({
   stardoc,
-  fileName,
 }) => {
   if (!stardoc) {
     return (
@@ -230,23 +228,32 @@ export const StardocRenderer: React.FC<StardocRendererProps> = ({
                   {/* Function parameters */}
                   {func.parameter && func.parameter.length > 0 && (
                     <div className="mt-3">
-                      <h5 className="text-sm font-medium text-gray-700 mb-2">
+                      <h5 className="text-sm font-bold text-gray-700 mb-2">
                         Parameters
                       </h5>
-                      <ul className="space-y-2">
-                        {func.parameter.map((param, paramIndex) => (
-                          <li key={paramIndex} className="text-sm">
-                            <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
-                              {param.name}
-                            </code>
-                            {param.docString && (
-                              <span className="ml-2 text-gray-600">
-                                - {param.docString}
-                              </span>
-                            )}
-                          </li>
-                        ))}
-                      </ul>
+                      <table className="w-full text-sm">
+                        <tbody>
+                          {func.parameter.map((param, paramIndex) => (
+                            <tr key={paramIndex}>
+                              <td className="align-top pr-3 py-1 w-32 whitespace-nowrap text-right">
+                                <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
+                                  {param.name}
+                                </code>
+                              </td>
+                              {param.docString && (
+                                <td className="align-top text-gray-600 py-1">
+                                  <ReactMarkdown
+                                    components={markdownComponents}
+                                    remarkPlugins={[remarkGfm, remarkBreaks]}
+                                  >
+                                    {param.docString}
+                                  </ReactMarkdown>
+                                </td>
+                              )}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
                     </div>
                   )}
                 </div>
@@ -292,20 +299,29 @@ export const StardocRenderer: React.FC<StardocRendererProps> = ({
                       <h5 className="text-sm font-medium text-gray-700 mb-2">
                         Attributes
                       </h5>
-                      <ul className="space-y-2">
-                        {rule.attribute.map((attr, attrIndex) => (
-                          <li key={attrIndex} className="text-sm">
-                            <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
-                              {attr.name}
-                            </code>
-                            {attr.docString && (
-                              <span className="ml-2 text-gray-600">
-                                - {attr.docString}
-                              </span>
-                            )}
-                          </li>
-                        ))}
-                      </ul>
+                      <table className="w-full text-sm">
+                        <tbody>
+                          {rule.attribute.map((attr, attrIndex) => (
+                            <tr key={attrIndex}>
+                              <td className="align-top pr-3 py-1 w-32 whitespace-nowrap text-right">
+                                <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
+                                  {attr.name}
+                                </code>
+                              </td>
+                              {attr.docString && (
+                                <td className="align-top text-gray-600 py-1">
+                                  <ReactMarkdown
+                                    components={markdownComponents}
+                                    remarkPlugins={[remarkGfm, remarkBreaks]}
+                                  >
+                                    {attr.docString}
+                                  </ReactMarkdown>
+                                </td>
+                              )}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
                     </div>
                   )}
                 </div>
@@ -354,20 +370,29 @@ export const StardocRenderer: React.FC<StardocRendererProps> = ({
                       <h5 className="text-sm font-medium text-gray-700 mb-2">
                         Fields
                       </h5>
-                      <ul className="space-y-2">
-                        {provider.fieldInfo.map((field, fieldIndex) => (
-                          <li key={fieldIndex} className="text-sm">
-                            <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
-                              {field.name}
-                            </code>
-                            {field.docString && (
-                              <span className="ml-2 text-gray-600">
-                                - {field.docString}
-                              </span>
-                            )}
-                          </li>
-                        ))}
-                      </ul>
+                      <table className="w-full text-sm">
+                        <tbody>
+                          {provider.fieldInfo.map((field, fieldIndex) => (
+                            <tr key={fieldIndex}>
+                              <td className="align-top pr-3 py-1 w-32 whitespace-nowrap text-right">
+                                <code className="bg-gray-100 px-2 py-1 rounded text-xs font-mono">
+                                  {field.name}
+                                </code>
+                              </td>
+                              {field.docString && (
+                                <td className="align-top text-gray-600 py-1">
+                                  <ReactMarkdown
+                                    components={markdownComponents}
+                                    remarkPlugins={[remarkGfm, remarkBreaks]}
+                                  >
+                                    {field.docString}
+                                  </ReactMarkdown>
+                                </td>
+                              )}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
                     </div>
                   )}
                 </div>

--- a/data/moduleStaticProps.ts
+++ b/data/moduleStaticProps.ts
@@ -7,7 +7,7 @@ import {
   ModuleInfo,
   reverseDependencies,
   getSourceJson,
-  fetchDocsArchiveFileList,
+  fetchDocsList,
   SourceJson,
 } from './utils'
 import { getGithubRepositoryMetadata } from './githubMetadata'
@@ -40,7 +40,7 @@ export const getStaticPropsModulePage = async (
     versions.map(async (version) => {
       const sourceJson = await getSourceJson(module, version)
       const binaryprotoFiles = sourceJson?.docs_url
-        ? await fetchDocsArchiveFileList(sourceJson.docs_url)
+        ? await fetchDocsList(sourceJson.docs_url)
         : []
 
       return {

--- a/data/moduleStaticProps.ts
+++ b/data/moduleStaticProps.ts
@@ -7,10 +7,10 @@ import {
   ModuleInfo,
   reverseDependencies,
   getSourceJson,
-  fetchDocsList,
   SourceJson,
 } from './utils'
 import { getGithubRepositoryMetadata } from './githubMetadata'
+import { fetchDocsList, StardocModuleInfo } from './stardoc'
 
 export interface VersionInfo {
   version: string
@@ -23,7 +23,7 @@ export interface VersionInfo {
   yankReason: string | null
   hasAttestationFile: boolean
   sourceJson: SourceJson | null
-  stardocs: string[]
+  stardocs: StardocModuleInfo[]
 }
 
 // [module]/[version] needs to reuse the same logic

--- a/data/moduleStaticProps.ts
+++ b/data/moduleStaticProps.ts
@@ -23,7 +23,7 @@ export interface VersionInfo {
   yankReason: string | null
   hasAttestationFile: boolean
   sourceJson: SourceJson | null
-  binaryprotoFiles: string[]
+  stardocs: string[]
 }
 
 // [module]/[version] needs to reuse the same logic
@@ -39,7 +39,7 @@ export const getStaticPropsModulePage = async (
   const versionInfos: VersionInfo[] = await Promise.all(
     versions.map(async (version) => {
       const sourceJson = await getSourceJson(module, version)
-      const binaryprotoFiles = sourceJson?.docs_url
+      const stardocs = sourceJson?.docs_url
         ? await fetchDocsList(sourceJson.docs_url)
         : []
 
@@ -51,7 +51,7 @@ export const getStaticPropsModulePage = async (
         yankReason: yankedVersions[version] || null,
         hasAttestationFile: await hasAttestationFile(module, version),
         sourceJson,
-        binaryprotoFiles,
+        stardocs,
       }
     })
   )

--- a/data/stardoc.ts
+++ b/data/stardoc.ts
@@ -1,0 +1,107 @@
+import { fromBinary } from '@bufbuild/protobuf'
+import {
+  ModuleInfoSchema,
+  ModuleInfo,
+} from '@buf/bazel_bazel.bufbuild_es/src/main/java/com/google/devtools/build/skydoc/rendering/proto/stardoc_output_pb.js'
+import * as tar from 'tar-stream'
+import * as zlib from 'zlib'
+import { Readable } from 'node:stream'
+
+export type StardocModuleInfo = ModuleInfo
+
+// Convert protobuf objects to plain JavaScript objects for JSON serialization
+function toPlainObject(obj: any): any {
+  if (obj === null || obj === undefined) {
+    return obj
+  }
+
+  if (obj instanceof Uint8Array) {
+    return Array.from(obj)
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(toPlainObject)
+  }
+
+  if (typeof obj === 'object') {
+    const result: any = {}
+    for (const [key, value] of Object.entries(obj)) {
+      // Skip protobuf internal fields
+      if (key.startsWith('$')) {
+        continue
+      }
+      result[key] = toPlainObject(value)
+    }
+    return result
+  }
+
+  return obj
+}
+
+export const fetchDocsList = async (docsUrl: string): Promise<ModuleInfo[]> => {
+  if (typeof window !== 'undefined') {
+    throw new Error('fetchDocsList should only be called server-side')
+  }
+
+  try {
+    const response = await fetch(docsUrl)
+    if (!response.ok) {
+      console.warn('Failed to fetch docs from ', docsUrl, response)
+      return []
+    }
+
+    const docsArchive = await response.arrayBuffer()
+    return new Promise((resolve, reject) => {
+      const extract = tar.extract()
+      const stardocs: ModuleInfo[] = []
+      extract.on('entry', (header, stream, next) => {
+        const chunks: any[] = []
+
+        stream.on('data', (chunk) => {
+          chunks.push(chunk)
+        })
+
+        stream.on('end', () => {
+          try {
+            const content = Buffer.concat(chunks)
+            if (
+              header.type === 'file' &&
+              header.name.endsWith('.binaryproto')
+            ) {
+              const stardoc = fromBinary(
+                ModuleInfoSchema,
+                new Uint8Array(content)
+              )
+              // Convert protobuf object to plain object for JSON serialization
+              stardocs.push(toPlainObject(stardoc) as ModuleInfo)
+            }
+            next()
+          } catch (err) {
+            next() // Continue processing other files even if one fails
+          }
+        })
+
+        stream.on('error', (err) => {
+          next() // Continue processing other files
+        })
+      })
+
+      extract.on('finish', () => {
+        resolve(stardocs.sort((a, b) => a.file.localeCompare(b.file)))
+      })
+
+      extract.on('error', (err) => {
+        reject(err)
+      })
+
+      Readable.from([Buffer.from(docsArchive)])
+        .pipe(zlib.createGunzip())
+        .pipe(extract)
+        .on('error', (err) => {
+          reject(err)
+        })
+    })
+  } catch (error) {
+    return []
+  }
+}

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -12,6 +12,8 @@ import * as os from 'os'
 import pMemoize from 'p-memoize'
 import * as yaml from 'js-yaml'
 import * as tar from 'tar-stream'
+import * as zlib from 'zlib'
+import { Readable } from 'node:stream'
 
 export const MODULES_ROOT_DIR = path.join(
   process.cwd(),
@@ -276,6 +278,7 @@ const buildAllModuleInfoInner = async (): Promise<AllModuleInfo> => {
         allModuleInfo.reverseDependencies[dependency.module] ||= new Set()
         allModuleInfo.reverseDependencies[dependency.module].add(moduleName)
       }
+      break
     }
   }
 
@@ -501,39 +504,97 @@ export const fetchDocsList = async (docsUrl: string): Promise<string[]> => {
   try {
     const response = await fetch(docsUrl)
     if (!response.ok) {
+      console.warn('Failed to fetch docs from ', docsUrl, response)
       return []
     }
 
-    const docsArchive = new Uint8Array(await response.arrayBuffer())
-    const stardocs: StardocModuleInfo[] = []
+    const docsArchive = await response.arrayBuffer()
+    console.warn('222 docsArchive', docsArchive)
+    return new Promise((resolve, reject) => {
+      const extract = tar.extract()
+      const stardocs: string[] = []
+      console.warn('111 extract')
 
-    const extract = tar.extract()
+      extract.on('entry', (header, stream, next) => {
+        console.warn('333 stream - processing entry:', header.name, header.type)
+        const chunks: any[] = []
 
-    extract.on('entry', (header, stream, next) => {
-      if (header.name.endsWith('.binaryproto')) {
-        const chunks: Uint8Array[] = []
-        stream.on('data', (chunk) => chunks.push(chunk))
-        stream.on('end', () => {
-          const bytes = Buffer.concat(chunks)
-          stardocs.push(fromBinary(ModuleInfoSchema, new Uint8Array(bytes)))
-          next()
+        stream.on('data', (chunk) => {
+          console.warn(
+            '444 data chunk received for:',
+            header.name,
+            chunk.length
+          )
+          chunks.push(chunk)
         })
-      } else {
-        stream.resume()
-        next()
-      }
+
+        stream.on('end', () => {
+          try {
+            const content = Buffer.concat(chunks)
+            console.warn(
+              '555 end - processing file:',
+              header.name,
+              'size:',
+              content.length
+            )
+
+            if (
+              header.type === 'file' &&
+              header.name.endsWith('.binaryproto')
+            ) {
+              const stardoc = fromBinary(
+                ModuleInfoSchema,
+                new Uint8Array(content)
+              )
+              stardocs.push(stardoc.moduleDocstring)
+              console.warn(
+                '666 pushed stardoc:',
+                header.name,
+                stardoc.moduleDocstring
+              )
+            }
+            next()
+          } catch (err) {
+            console.warn('777 error processing file:', header.name, err)
+            next() // Continue processing other files even if one fails
+          }
+        })
+
+        stream.on('error', (err) => {
+          console.warn('888 stream error for:', header.name, err)
+          next() // Continue processing other files
+        })
+      })
+
+      extract.on('finish', () => {
+        console.warn(
+          '999 extraction finished, found',
+          stardocs.length,
+          'stardocs'
+        )
+        resolve(stardocs)
+      })
+
+      extract.on('error', (err) => {
+        console.warn('000 extract error:', err)
+        reject(err)
+      })
+
+      // Turn the Uint8Array into a Readable stream and pipe through gunzip + tar
+      console.warn(
+        '111 starting pipe from docsArchive, size:',
+        docsArchive.byteLength
+      )
+      Readable.from([Buffer.from(docsArchive)])
+        .pipe(zlib.createGunzip())
+        .pipe(extract)
+        .on('error', (err) => {
+          console.warn('222 pipe error:', err)
+          reject(err)
+        })
     })
-
-    extract.end(docsArchive)
-
-    // Wait for extraction to complete
-    await new Promise<void>((resolve, reject) => {
-      extract.on('finish', resolve)
-      extract.on('error', reject)
-    })
-
-    return stardocs.map((stardoc) => stardoc.moduleDocstring)
   } catch (error) {
+    console.warn('333 error', error)
     return []
   }
 }

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -1,7 +1,9 @@
+import { fromBinary } from '@bufbuild/protobuf'
+import { ModuleInfoSchema } from '@buf/bazel_bazel.bufbuild_es/src/main/java/com/google/devtools/build/skydoc/rendering/proto/stardoc_output_pb.js'
 import path from 'path'
 import { formatISO, parse } from 'date-fns'
 import { execa } from 'execa'
-import { promises as fs } from 'fs'
+import { promises as fs } from 'node:fs'
 import { gitlogPromise } from 'gitlog'
 import * as os from 'os'
 import pMemoize from 'p-memoize'
@@ -487,13 +489,9 @@ export const getSourceJson = async (
   }
 }
 
-export const fetchDocsArchiveFileList = async (
-  docsUrl: string
-): Promise<string[]> => {
+export const fetchDocsList = async (docsUrl: string): Promise<string[]> => {
   if (typeof window !== 'undefined') {
-    throw new Error(
-      'fetchDocsArchiveFileList should only be called server-side'
-    )
+    throw new Error('fetchDocsList should only be called server-side')
   }
 
   try {
@@ -507,7 +505,7 @@ export const fetchDocsArchiveFileList = async (
 
     const tempFile = path.join(os.tmpdir(), `docs-${Date.now()}.tar.gz`)
     await fs.writeFile(tempFile, buffer)
-
+    const moduleDocs = []
     try {
       const { stdout } = await execa('tar', ['-tzf', tempFile])
       const files = stdout
@@ -516,7 +514,16 @@ export const fetchDocsArchiveFileList = async (
         .map((file) => file.replace(/^\.\//, '').trim())
         .sort()
 
-      return files
+      for (const file of files) {
+        const protoInputPath = path.join(os.tmpdir(), file)
+        const bytes = await fs.readFile(protoInputPath)
+        const currentDoc = fromBinary(ModuleInfoSchema, bytes)
+        moduleDocs.push(
+          currentDoc.funcInfo.map((func) => func.functionName).join(', ')
+        )
+      }
+
+      return moduleDocs
     } finally {
       try {
         await fs.unlink(tempFile)

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -260,9 +260,6 @@ const buildAllModuleInfoInner = async (): Promise<AllModuleInfo> => {
 
   const modulesNames = await listModuleNames()
   for (const moduleName of modulesNames) {
-    if (moduleName !== 'bazel_lib') {
-      continue
-    }
     const versions = await listModuleVersions(moduleName)
     for (const moduleVersion of versions) {
       const moduleInfo = await extractModuleInfo(moduleName, moduleVersion)
@@ -273,7 +270,6 @@ const buildAllModuleInfoInner = async (): Promise<AllModuleInfo> => {
         allModuleInfo.reverseDependencies[dependency.module] ||= new Set()
         allModuleInfo.reverseDependencies[dependency.module].add(moduleName)
       }
-      break
     }
   }
 

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -260,6 +260,9 @@ const buildAllModuleInfoInner = async (): Promise<AllModuleInfo> => {
 
   const modulesNames = await listModuleNames()
   for (const moduleName of modulesNames) {
+    if (moduleName !== 'bazel_lib') {
+      continue
+    }
     const versions = await listModuleVersions(moduleName)
     for (const moduleVersion of versions) {
       const moduleInfo = await extractModuleInfo(moduleName, moduleVersion)
@@ -270,6 +273,7 @@ const buildAllModuleInfoInner = async (): Promise<AllModuleInfo> => {
         allModuleInfo.reverseDependencies[dependency.module] ||= new Set()
         allModuleInfo.reverseDependencies[dependency.module].add(moduleName)
       }
+      break
     }
   }
 

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -1,19 +1,11 @@
-import { fromBinary } from '@bufbuild/protobuf'
-import {
-  ModuleInfoSchema,
-  ModuleInfo as StardocModuleInfo,
-} from '@buf/bazel_bazel.bufbuild_es/src/main/java/com/google/devtools/build/skydoc/rendering/proto/stardoc_output_pb.js'
 import path from 'path'
 import { formatISO, parse } from 'date-fns'
 import { execa } from 'execa'
-import { promises as fs } from 'node:fs'
+import { promises as fs } from 'fs'
 import { gitlogPromise } from 'gitlog'
 import * as os from 'os'
 import pMemoize from 'p-memoize'
 import * as yaml from 'js-yaml'
-import * as tar from 'tar-stream'
-import * as zlib from 'zlib'
-import { Readable } from 'node:stream'
 
 export const MODULES_ROOT_DIR = path.join(
   process.cwd(),
@@ -278,7 +270,6 @@ const buildAllModuleInfoInner = async (): Promise<AllModuleInfo> => {
         allModuleInfo.reverseDependencies[dependency.module] ||= new Set()
         allModuleInfo.reverseDependencies[dependency.module].add(moduleName)
       }
-      break
     }
   }
 
@@ -493,108 +484,5 @@ export const getSourceJson = async (
     return JSON.parse(sourceContents) as SourceJson
   } catch {
     return null
-  }
-}
-
-export const fetchDocsList = async (docsUrl: string): Promise<string[]> => {
-  if (typeof window !== 'undefined') {
-    throw new Error('fetchDocsList should only be called server-side')
-  }
-
-  try {
-    const response = await fetch(docsUrl)
-    if (!response.ok) {
-      console.warn('Failed to fetch docs from ', docsUrl, response)
-      return []
-    }
-
-    const docsArchive = await response.arrayBuffer()
-    console.warn('222 docsArchive', docsArchive)
-    return new Promise((resolve, reject) => {
-      const extract = tar.extract()
-      const stardocs: string[] = []
-      console.warn('111 extract')
-
-      extract.on('entry', (header, stream, next) => {
-        console.warn('333 stream - processing entry:', header.name, header.type)
-        const chunks: any[] = []
-
-        stream.on('data', (chunk) => {
-          console.warn(
-            '444 data chunk received for:',
-            header.name,
-            chunk.length
-          )
-          chunks.push(chunk)
-        })
-
-        stream.on('end', () => {
-          try {
-            const content = Buffer.concat(chunks)
-            console.warn(
-              '555 end - processing file:',
-              header.name,
-              'size:',
-              content.length
-            )
-
-            if (
-              header.type === 'file' &&
-              header.name.endsWith('.binaryproto')
-            ) {
-              const stardoc = fromBinary(
-                ModuleInfoSchema,
-                new Uint8Array(content)
-              )
-              stardocs.push(stardoc.moduleDocstring)
-              console.warn(
-                '666 pushed stardoc:',
-                header.name,
-                stardoc.moduleDocstring
-              )
-            }
-            next()
-          } catch (err) {
-            console.warn('777 error processing file:', header.name, err)
-            next() // Continue processing other files even if one fails
-          }
-        })
-
-        stream.on('error', (err) => {
-          console.warn('888 stream error for:', header.name, err)
-          next() // Continue processing other files
-        })
-      })
-
-      extract.on('finish', () => {
-        console.warn(
-          '999 extraction finished, found',
-          stardocs.length,
-          'stardocs'
-        )
-        resolve(stardocs)
-      })
-
-      extract.on('error', (err) => {
-        console.warn('000 extract error:', err)
-        reject(err)
-      })
-
-      // Turn the Uint8Array into a Readable stream and pipe through gunzip + tar
-      console.warn(
-        '111 starting pipe from docsArchive, size:',
-        docsArchive.byteLength
-      )
-      Readable.from([Buffer.from(docsArchive)])
-        .pipe(zlib.createGunzip())
-        .pipe(extract)
-        .on('error', (err) => {
-          console.warn('222 pipe error:', err)
-          reject(err)
-        })
-    })
-  } catch (error) {
-    console.warn('333 error', error)
-    return []
   }
 }

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -1,5 +1,8 @@
 import { fromBinary } from '@bufbuild/protobuf'
-import { ModuleInfoSchema } from '@buf/bazel_bazel.bufbuild_es/src/main/java/com/google/devtools/build/skydoc/rendering/proto/stardoc_output_pb.js'
+import {
+  ModuleInfoSchema,
+  ModuleInfo as StardocModuleInfo,
+} from '@buf/bazel_bazel.bufbuild_es/src/main/java/com/google/devtools/build/skydoc/rendering/proto/stardoc_output_pb.js'
 import path from 'path'
 import { formatISO, parse } from 'date-fns'
 import { execa } from 'execa'
@@ -8,6 +11,7 @@ import { gitlogPromise } from 'gitlog'
 import * as os from 'os'
 import pMemoize from 'p-memoize'
 import * as yaml from 'js-yaml'
+import * as tar from 'tar-stream'
 
 export const MODULES_ROOT_DIR = path.join(
   process.cwd(),
@@ -500,35 +504,35 @@ export const fetchDocsList = async (docsUrl: string): Promise<string[]> => {
       return []
     }
 
-    const arrayBuffer = await response.arrayBuffer()
-    const buffer = Buffer.from(arrayBuffer)
+    const docsArchive = new Uint8Array(await response.arrayBuffer())
+    const stardocs: StardocModuleInfo[] = []
 
-    const tempFile = path.join(os.tmpdir(), `docs-${Date.now()}.tar.gz`)
-    await fs.writeFile(tempFile, buffer)
-    const moduleDocs = []
-    try {
-      const { stdout } = await execa('tar', ['-tzf', tempFile])
-      const files = stdout
-        .split('\n')
-        .filter((file) => file.trim() && file.endsWith('.binaryproto'))
-        .map((file) => file.replace(/^\.\//, '').trim())
-        .sort()
+    const extract = tar.extract()
 
-      for (const file of files) {
-        const protoInputPath = path.join(os.tmpdir(), file)
-        const bytes = await fs.readFile(protoInputPath)
-        const currentDoc = fromBinary(ModuleInfoSchema, bytes)
-        moduleDocs.push(
-          currentDoc.funcInfo.map((func) => func.functionName).join(', ')
-        )
+    extract.on('entry', (header, stream, next) => {
+      if (header.name.endsWith('.binaryproto')) {
+        const chunks: Uint8Array[] = []
+        stream.on('data', (chunk) => chunks.push(chunk))
+        stream.on('end', () => {
+          const bytes = Buffer.concat(chunks)
+          stardocs.push(fromBinary(ModuleInfoSchema, new Uint8Array(bytes)))
+          next()
+        })
+      } else {
+        stream.resume()
+        next()
       }
+    })
 
-      return moduleDocs
-    } finally {
-      try {
-        await fs.unlink(tempFile)
-      } catch {}
-    }
+    extract.end(docsArchive)
+
+    // Wait for extraction to complete
+    await new Promise<void>((resolve, reject) => {
+      extract.on('finish', resolve)
+      extract.on('error', reject)
+    })
+
+    return stardocs.map((stardoc) => stardoc.moduleDocstring)
   } catch (error) {
     return []
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "prettier-fix": "prettier --write ."
   },
   "dependencies": {
+    "@buf/bazel_bazel.bufbuild_es": "2.0.0-20240806194025-8f5cf9629ba6.1",
+    "@bufbuild/protobuf": "^2",
     "@floating-ui/react-dom": "^2.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-brands-svg-icons": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-config-next": "15.5.3",
     "postcss": "~8.4.14",
     "prettier": "^3.0.0",
+    "react-markdown": "^10.1.0",
     "tailwindcss": "~3.1.3",
     "typescript": "5.2.2",
     "zlib": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/node": "18.17.9",
     "@types/react": "19.1.13",
     "@types/react-dom": "19.1.9",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "autoprefixer": "^10.4.7",
     "eslint": "8.53.0",
     "eslint-config-next": "15.5.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "prettier": "^3.0.0",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.6",
+    "remark-breaks": "^4.0.0",
+    "remark-gfm": "^4.0.1",
     "tailwindcss": "~3.1.3",
     "typescript": "5.2.2",
     "zlib": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "postcss": "~8.4.14",
     "prettier": "^3.0.0",
     "react-markdown": "^10.1.0",
+    "react-syntax-highlighter": "^15.6.6",
     "tailwindcss": "~3.1.3",
     "typescript": "5.2.2",
     "zlib": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "postcss": "~8.4.14",
     "prettier": "^3.0.0",
     "tailwindcss": "~3.1.3",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "zlib": "^1.0.5"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^3.0.2",
+    "@types/tar-stream": "^3.1.4",
     "compare-versions": "6.1.1",
     "date-fns": "^2.28.0",
     "execa": "^8.0.0",
@@ -30,7 +31,8 @@
     "next": "15.5.3",
     "p-memoize": "^7.1.1",
     "react": "19.1.1",
-    "react-dom": "19.1.1"
+    "react-dom": "19.1.1",
+    "tar-stream": "^3.1.7"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -12,6 +12,7 @@ import { CopyCode } from '../../components/CopyCode'
 import { AttestationBadge } from '../../components/AttestationBadge'
 import { PlatformSupport } from '../../components/PlatformSupport'
 import { BazelVersionSupport } from '../../components/BazelVersionSupport'
+import { StardocRenderer } from '../../components/Stardoc'
 import React, { useEffect, useState } from 'react'
 import {
   getStaticPropsModulePage,
@@ -116,7 +117,7 @@ const ModulePage: NextPage<ModulePageProps> = ({
 
       <Header />
       <main>
-        <div className="max-w-4xl w-4xl mx-auto mt-8">
+        <div className="w-4xl mx-auto mt-8">
           <div className="border rounded p-4 divide-y">
             <div className="flex items-center gap-1">
               {versionInfo.hasAttestationFile && (
@@ -370,39 +371,19 @@ const ModulePage: NextPage<ModulePageProps> = ({
                 </div>
 
                 {versionInfo.stardocs.length > 0 && (
-                  <div className="mt-4">
-                    <h2 className="text-2xl font-bold mt-4">
+                  <div className="mt-6">
+                    <h2 className="text-2xl font-bold mb-4">
                       Starlark API Documentation
                     </h2>
-                    {versionInfo.stardocs.map(
-                      (moduleInfo: StardocModuleInfo) => (
-                        <li
-                          key={moduleInfo.file}
-                          className="border rounded p-2 mt-2 flex items-center gap-4"
-                        >
-                          <details>
-                            <summary>
-                              <span
-                                role="heading"
-                                aria-level={2}
-                                className="text-1xl mt-4"
-                              >
-                                <span className="font-bold font-mono">
-                                  {moduleInfo.file}
-                                </span>
-                              </span>
-                            </summary>
-                            <ul className="mt-4">
-                              <div className="text-sm text-gray-700">
-                                <ReactMarkdown>
-                                  {moduleInfo.moduleDocstring}
-                                </ReactMarkdown>
-                              </div>
-                            </ul>
-                          </details>
-                        </li>
-                      )
-                    )}
+                    <div className="space-y-4">
+                      {versionInfo.stardocs.map((stardoc, index) => (
+                        <StardocRenderer
+                          key={stardoc.file || index}
+                          stardoc={stardoc}
+                          fileName={stardoc.file}
+                        />
+                      ))}
+                    </div>
                   </div>
                 )}
               </div>

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -21,8 +21,6 @@ import {
 import { GithubRepositoryMetadata } from '../../data/githubMetadata'
 import { formatDistance, parseISO } from 'date-fns'
 import { faGlobe, faScaleBalanced } from '@fortawesome/free-solid-svg-icons'
-import { StardocModuleInfo } from '../../data/stardoc'
-import ReactMarkdown from 'react-markdown'
 
 interface ModulePageProps {
   metadata: Metadata
@@ -117,400 +115,390 @@ const ModulePage: NextPage<ModulePageProps> = ({
 
       <Header />
       <main>
-        <div className="w-4xl mx-auto mt-8">
-          <div className="border rounded p-4 divide-y">
-            <div className="flex items-center gap-1">
-              {versionInfo.hasAttestationFile && (
-                <span className="w-7 h-7 inline-block">
-                  <AttestationBadge
-                    hasAttestationFile={true}
-                    placement="bottom-start"
-                  />
-                </span>
-              )}
-              <span
-                role="heading"
-                aria-level={1}
-                className="text-3xl translate-y-[-3px]"
-              >
-                {module}
+        <div className="border rounded p-4 divide-y">
+          <div className="flex items-center gap-1">
+            {versionInfo.hasAttestationFile && (
+              <span className="w-7 h-7 inline-block">
+                <AttestationBadge
+                  hasAttestationFile={true}
+                  placement="bottom-start"
+                />
               </span>
-              <span className="text-lg ml-2">{selectedVersion}</span>
-            </div>
-            <div className="mt-4 flex flex-col md:flex-row flex-wrap sm:divide-x gap-2">
-              <div id="install_history_dependencies" className="basis-0 grow">
-                <h2 className="text-2xl font-bold mt-4">Install</h2>
-                <div className="mt-2">
+            )}
+            <span
+              role="heading"
+              aria-level={1}
+              className="text-3xl translate-y-[-3px]"
+            >
+              {module}
+            </span>
+            <span className="text-lg ml-2">{selectedVersion}</span>
+          </div>
+          <div className="mt-4 flex flex-col md:flex-row flex-wrap sm:divide-x gap-2">
+            <div id="install_history_dependencies" className="basis-0 grow">
+              <h2 className="text-2xl font-bold mt-4">Install</h2>
+              <div className="mt-2">
+                <p>
+                  To start using this module, make sure you have set up Bzlmod
+                  according to the <a href={USER_GUIDE_LINK}>user guide</a>, and
+                  add the following to your <code>MODULE.bazel</code> file:
+                </p>
+                <CopyCode
+                  code={`bazel_dep(name = "${module}", version = "${selectedVersion}")`}
+                />
+                {!!releaseNotesLink && (
                   <p>
-                    To start using this module, make sure you have set up Bzlmod
-                    according to the <a href={USER_GUIDE_LINK}>user guide</a>,
-                    and add the following to your <code>MODULE.bazel</code>{' '}
-                    file:
+                    Read the{' '}
+                    <a
+                      href={releaseNotesLink}
+                      className="text-link-color hover:text-link-color-hover"
+                    >
+                      Release Notes
+                    </a>
                   </p>
-                  <CopyCode
-                    code={`bazel_dep(name = "${module}", version = "${selectedVersion}")`}
-                  />
-                  {!!releaseNotesLink && (
-                    <p>
-                      Read the{' '}
-                      <a
-                        href={releaseNotesLink}
-                        className="text-link-color hover:text-link-color-hover"
+                )}
+              </div>
+              <h2 className="text-2xl font-bold mt-4">Version history</h2>
+              <div>
+                <ul className="mt-4">
+                  {shownVersions.map((version) => (
+                    <>
+                      <li
+                        key={version.version}
+                        className="border rounded mt-2 "
                       >
-                        Release Notes
-                      </a>
-                    </p>
-                  )}
-                </div>
-                <h2 className="text-2xl font-bold mt-4">Version history</h2>
-                <div>
-                  <ul className="mt-4">
-                    {shownVersions.map((version) => (
-                      <>
-                        <li
-                          key={version.version}
-                          className="border rounded mt-2 "
-                        >
-                          {version.isYanked && (
-                            <div
-                              key={`${version.version}-yanked`}
-                              className="p-2 mb-2 bg-amber-300"
+                        {version.isYanked && (
+                          <div
+                            key={`${version.version}-yanked`}
+                            className="p-2 mb-2 bg-amber-300"
+                          >
+                            <a
+                              href="https://bazel.build/external/module#yanked_versions"
+                              className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
                             >
-                              <a
-                                href="https://bazel.build/external/module#yanked_versions"
-                                className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
+                              Version yanked
+                            </a>{' '}
+                            with comment: <p>{version.yankReason}</p>
+                          </div>
+                        )}
+                        <div className="flex items-stretch gap-4">
+                          <div className="flex flex-1 justify-between">
+                            <div className="flex p-2 flex-col gap-2 justify-between border-r hover:border-link-color hover:border-r-4">
+                              <Link
+                                href={`/modules/${module}/${version.version}`}
                               >
-                                Version yanked
-                              </a>{' '}
-                              with comment: <p>{version.yankReason}</p>
-                            </div>
-                          )}
-                          <div className="flex items-stretch gap-4">
-                            <div className="flex flex-1 justify-between">
-                              <div className="flex p-2 flex-col gap-2 justify-between border-r hover:border-link-color hover:border-r-4">
-                                <Link
-                                  href={`/modules/${module}/${version.version}`}
+                                <div className="place-items-center hover:border-gray-800 flex items-center gap-2">
+                                  {version.version}
+                                  <AttestationBadge
+                                    hasAttestationFile={
+                                      version.hasAttestationFile
+                                    }
+                                  />
+                                </div>
+                              </Link>
+                              <div className="self-end text-gray-500">
+                                <a
+                                  href="https://bazel.build/external/module#compatibility_level"
+                                  className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
                                 >
-                                  <div className="place-items-center hover:border-gray-800 flex items-center gap-2">
-                                    {version.version}
-                                    <AttestationBadge
-                                      hasAttestationFile={
-                                        version.hasAttestationFile
-                                      }
-                                    />
-                                  </div>
-                                </Link>
-                                <div className="self-end text-gray-500">
-                                  <a
-                                    href="https://bazel.build/external/module#compatibility_level"
-                                    className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
-                                  >
-                                    compatibility level
-                                  </a>{' '}
-                                  {version.moduleInfo.compatibilityLevel}
-                                </div>
+                                  compatibility level
+                                </a>{' '}
+                                {version.moduleInfo.compatibilityLevel}
                               </div>
-                              <div className="flex p-2 justify-end">
-                                <div className="flex flex-col justify-between items-end">
-                                  <a
-                                    href={`https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/${module}/${version.version}`}
-                                    className="text-link-color hover:text-link-color-hover"
-                                  >
-                                    view registry source
-                                  </a>
-                                  <a
-                                    href={`https://github.com/bazelbuild/bazel-central-registry/commit/${version.submission.hash}`}
-                                    className="text-link-color hover:text-link-color-hover"
-                                    suppressHydrationWarning
-                                  >
-                                    published{' '}
-                                    {formatDistance(
-                                      parseISO(
-                                        version.submission.authorDateIso
-                                      ),
-                                      new Date(),
-                                      { addSuffix: true }
-                                    )}
-                                  </a>
-                                </div>
+                            </div>
+                            <div className="flex p-2 justify-end">
+                              <div className="flex flex-col justify-between items-end">
+                                <a
+                                  href={`https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/${module}/${version.version}`}
+                                  className="text-link-color hover:text-link-color-hover"
+                                >
+                                  view registry source
+                                </a>
+                                <a
+                                  href={`https://github.com/bazelbuild/bazel-central-registry/commit/${version.submission.hash}`}
+                                  className="text-link-color hover:text-link-color-hover"
+                                  suppressHydrationWarning
+                                >
+                                  published{' '}
+                                  {formatDistance(
+                                    parseISO(version.submission.authorDateIso),
+                                    new Date(),
+                                    { addSuffix: true }
+                                  )}
+                                </a>
                               </div>
                             </div>
                           </div>
-                        </li>
-                      </>
-                    ))}
-                  </ul>
-                  {displayShowAllVersionsButton && (
-                    <button
-                      className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
-                      onClick={() => setTriggeredShowAllVersions(true)}
+                        </div>
+                      </li>
+                    </>
+                  ))}
+                </ul>
+                {displayShowAllVersionsButton && (
+                  <button
+                    className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
+                    onClick={() => setTriggeredShowAllVersions(true)}
+                  >
+                    Show all {versionInfos.length} versions
+                  </button>
+                )}
+              </div>
+              <div className="mt-4">
+                <h2 className="text-2xl font-bold mt-4">Dependency graph</h2>
+              </div>
+              <div className="mt-4">
+                <details open>
+                  <summary>
+                    <span
+                      role="heading"
+                      aria-level={2}
+                      className="text-1xl mt-4"
                     >
-                      Show all {versionInfos.length} versions
-                    </button>
-                  )}
-                </div>
-                <div className="mt-4">
-                  <h2 className="text-2xl font-bold mt-4">Dependency graph</h2>
-                </div>
-                <div className="mt-4">
-                  <details open>
-                    <summary>
-                      <span
-                        role="heading"
-                        aria-level={2}
-                        className="text-1xl mt-4"
-                      >
-                        <span className="font-bold">Direct</span> (
-                        {versionInfo.moduleInfo.dependencies.filter(
-                          (d) => !d.dev
-                        ).length || 'None'}
-                        ){' '}
-                        <small className="text-sm font-normal text-gray-500">
-                          at version {selectedVersion}
-                        </small>
-                      </span>
-                    </summary>
-                    <ul className="mt-4">
-                      {versionInfo.moduleInfo.dependencies
-                        .filter((d) => !d.dev)
-                        .map((dependency) => (
-                          <Link
-                            key={dependency.module}
-                            href={`/modules/${dependency.module}/${dependency.version}`}
-                          >
-                            <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
-                              <div className="rounded-full border h-14 w-14 grid place-items-center">
-                                {dependency.version}
-                              </div>
-                              <div>{dependency.module}</div>
-                            </li>
-                          </Link>
-                        ))}
+                      <span className="font-bold">Direct</span> (
                       {versionInfo.moduleInfo.dependencies.filter((d) => !d.dev)
-                        .length === 0 && <span>No dependencies</span>}
-                    </ul>
-                  </details>
-                </div>
-                <div className="mt-4">
-                  <details>
-                    <summary>
-                      <span
-                        role="heading"
-                        aria-level={2}
-                        className="text-1xl mt-4"
-                      >
-                        <span className="font-bold">Dev Dependencies</span> (
-                        {versionInfo.moduleInfo.dependencies.filter(
-                          (d) => d.dev
-                        ).length || 'None'}
-                        ){' '}
-                      </span>
-                    </summary>
-                    <ul className="mt-4">
-                      {versionInfo.moduleInfo.dependencies
-                        .filter((d) => d.dev)
-                        .map((dependency) => (
-                          <Link
-                            key={dependency.module}
-                            href={`/modules/${dependency.module}/${dependency.version}`}
-                          >
-                            <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
-                              <div className="rounded-full border h-14 w-14 grid place-items-center">
-                                {dependency.version}
-                              </div>
-                              <div>{dependency.module}</div>
-                            </li>
-                          </Link>
-                        ))}
-                      {versionInfo.moduleInfo.dependencies.length === 0 && (
-                        <span>No dependencies</span>
-                      )}
-                    </ul>
-                  </details>
-                </div>
-                <div className="mt-4">
-                  <details>
-                    <summary>
-                      <span
-                        role="heading"
-                        aria-level={2}
-                        className="text-1xl mt-4"
-                      >
-                        <span className="font-bold">Dependents</span>{' '}
-                        {reverseDependencies.length > 0
-                          ? `(${reverseDependencies.length})`
-                          : ''}
-                      </span>
-                    </summary>
-                    <ul className="mt-4">
-                      {shownReverseDependencies.map((revDependency) => (
+                        .length || 'None'}
+                      ){' '}
+                      <small className="text-sm font-normal text-gray-500">
+                        at version {selectedVersion}
+                      </small>
+                    </span>
+                  </summary>
+                  <ul className="mt-4">
+                    {versionInfo.moduleInfo.dependencies
+                      .filter((d) => !d.dev)
+                      .map((dependency) => (
                         <Link
-                          key={revDependency}
-                          href={`/modules/${revDependency}`}
+                          key={dependency.module}
+                          href={`/modules/${dependency.module}/${dependency.version}`}
                         >
                           <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
-                            <div>{revDependency}</div>
+                            <div className="rounded-full border h-14 w-14 grid place-items-center">
+                              {dependency.version}
+                            </div>
+                            <div>{dependency.module}</div>
                           </li>
                         </Link>
                       ))}
-                      {reverseDependencies.length === 0 && (
-                        <span>No dependent modules yet</span>
-                      )}
-                    </ul>
-                    {displayShowAllReverseDependenciesButton && (
-                      <button
-                        className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
-                        onClick={() =>
-                          setTriggeredShowAllReverseDependencies(true)
-                        }
-                      >
-                        Show all {reverseDependencies.length} dependent modules
-                      </button>
-                    )}
-                  </details>
-                </div>
-
-                {versionInfo.stardocs.length > 0 && (
-                  <div className="mt-6">
-                    <h2 className="text-2xl font-bold mb-4">
-                      Starlark API Documentation
-                    </h2>
-                    <div className="space-y-4">
-                      {versionInfo.stardocs.map((stardoc, index) => (
-                        <StardocRenderer
-                          key={stardoc.file || index}
-                          stardoc={stardoc}
-                          fileName={stardoc.file}
-                        />
+                    {versionInfo.moduleInfo.dependencies.filter((d) => !d.dev)
+                      .length === 0 && <span>No dependencies</span>}
+                  </ul>
+                </details>
+              </div>
+              <div className="mt-4">
+                <details>
+                  <summary>
+                    <span
+                      role="heading"
+                      aria-level={2}
+                      className="text-1xl mt-4"
+                    >
+                      <span className="font-bold">Dev Dependencies</span> (
+                      {versionInfo.moduleInfo.dependencies.filter((d) => d.dev)
+                        .length || 'None'}
+                      ){' '}
+                    </span>
+                  </summary>
+                  <ul className="mt-4">
+                    {versionInfo.moduleInfo.dependencies
+                      .filter((d) => d.dev)
+                      .map((dependency) => (
+                        <Link
+                          key={dependency.module}
+                          href={`/modules/${dependency.module}/${dependency.version}`}
+                        >
+                          <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
+                            <div className="rounded-full border h-14 w-14 grid place-items-center">
+                              {dependency.version}
+                            </div>
+                            <div>{dependency.module}</div>
+                          </li>
+                        </Link>
                       ))}
-                    </div>
+                    {versionInfo.moduleInfo.dependencies.length === 0 && (
+                      <span>No dependencies</span>
+                    )}
+                  </ul>
+                </details>
+              </div>
+              <div className="mt-4">
+                <details>
+                  <summary>
+                    <span
+                      role="heading"
+                      aria-level={2}
+                      className="text-1xl mt-4"
+                    >
+                      <span className="font-bold">Dependents</span>{' '}
+                      {reverseDependencies.length > 0
+                        ? `(${reverseDependencies.length})`
+                        : ''}
+                    </span>
+                  </summary>
+                  <ul className="mt-4">
+                    {shownReverseDependencies.map((revDependency) => (
+                      <Link
+                        key={revDependency}
+                        href={`/modules/${revDependency}`}
+                      >
+                        <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
+                          <div>{revDependency}</div>
+                        </li>
+                      </Link>
+                    ))}
+                    {reverseDependencies.length === 0 && (
+                      <span>No dependent modules yet</span>
+                    )}
+                  </ul>
+                  {displayShowAllReverseDependenciesButton && (
+                    <button
+                      className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
+                      onClick={() =>
+                        setTriggeredShowAllReverseDependencies(true)
+                      }
+                    >
+                      Show all {reverseDependencies.length} dependent modules
+                    </button>
+                  )}
+                </details>
+              </div>
+            </div>
+            <div id="metadata" className="sm:pl-2 basis-8 md:basis-[12rem]">
+              <h2 className="text-2xl font-bold mt-4 mb-2">About</h2>
+              <div>
+                {repoDescription && (
+                  <div className="mb-2">
+                    <p className="text-md">{repoDescription}</p>
                   </div>
                 )}
-              </div>
-              <div id="metadata" className="sm:pl-2 basis-8 md:basis-[12rem]">
-                <h2 className="text-2xl font-bold mt-4 mb-2">About</h2>
-                <div>
-                  {repoDescription && (
-                    <div className="mb-2">
-                      <p className="text-md">{repoDescription}</p>
+                <div className="space-y-1">
+                  {repoTopics && (
+                    <div className="mb-4 mt-4 flex flex-row flex-wrap gap-1">
+                      {repoTopics.map((topic) => {
+                        return (
+                          <span
+                            className="rounded-xl pl-3 pr-3 pt-0.5 pb-0.5 font-semibold mr-1 text-sm text-[#0b713b] bg-[#0b713b1a]"
+                            key={topic}
+                          >
+                            {topic}
+                          </span>
+                        )
+                      })}
                     </div>
                   )}
-                  <div className="space-y-1">
-                    {repoTopics && (
-                      <div className="mb-4 mt-4 flex flex-row flex-wrap gap-1">
-                        {repoTopics.map((topic) => {
-                          return (
-                            <span
-                              className="rounded-xl pl-3 pr-3 pt-0.5 pb-0.5 font-semibold mr-1 text-sm text-[#0b713b] bg-[#0b713b1a]"
-                              key={topic}
-                            >
-                              {topic}
-                            </span>
-                          )
-                        })}
-                      </div>
-                    )}
 
-                    {metadata.homepage !== githubLink ? (
+                  {metadata.homepage !== githubLink ? (
+                    <a
+                      href={metadata.homepage}
+                      className="block text-link-color hover:text-link-color-hover"
+                      title={metadata.homepage}
+                    >
+                      <FontAwesomeIcon
+                        icon={faGlobe}
+                        className="mr-1 min-w-[30px]"
+                      />
+                      Homepage
+                    </a>
+                  ) : null}
+
+                  {repoStargazers && (
+                    <div className="text-black">
+                      <FontAwesomeIcon
+                        className="mr-1 min-w-[30px]"
+                        icon={faStar}
+                      />
+                      {repoStargazers} Stars
+                    </div>
+                  )}
+
+                  {repoLicense && (
+                    <a
+                      href={repoLicense.url}
+                      className="block text-link-color hover:text-link-color-hover cursor-pointer"
+                      title={repoLicense.spdx_id}
+                    >
+                      <FontAwesomeIcon
+                        className="mr-1 min-w-[30px]"
+                        icon={faScaleBalanced}
+                      />
+                      {repoLicense.name}
+                    </a>
+                  )}
+
+                  {githubLink && (
+                    <div>
                       <a
-                        href={metadata.homepage}
-                        className="block text-link-color hover:text-link-color-hover"
-                        title={metadata.homepage}
+                        href={githubLink}
+                        className="text-link-color hover:text-link-color-hover"
+                        title={githubLink}
                       >
                         <FontAwesomeIcon
-                          icon={faGlobe}
+                          icon={faGithub}
                           className="mr-1 min-w-[30px]"
                         />
-                        Homepage
+                        GitHub repository
                       </a>
-                    ) : null}
-
-                    {repoStargazers && (
-                      <div className="text-black">
-                        <FontAwesomeIcon
-                          className="mr-1 min-w-[30px]"
-                          icon={faStar}
-                        />
-                        {repoStargazers} Stars
-                      </div>
-                    )}
-
-                    {repoLicense && (
-                      <a
-                        href={repoLicense.url}
-                        className="block text-link-color hover:text-link-color-hover cursor-pointer"
-                        title={repoLicense.spdx_id}
-                      >
-                        <FontAwesomeIcon
-                          className="mr-1 min-w-[30px]"
-                          icon={faScaleBalanced}
-                        />
-                        {repoLicense.name}
-                      </a>
-                    )}
-
-                    {githubLink && (
-                      <div>
-                        <a
-                          href={githubLink}
-                          className="text-link-color hover:text-link-color-hover"
-                          title={githubLink}
-                        >
-                          <FontAwesomeIcon
-                            icon={faGithub}
-                            className="mr-1 min-w-[30px]"
-                          />
-                          GitHub repository
-                        </a>
-                      </div>
-                    )}
-                  </div>
+                    </div>
+                  )}
                 </div>
+              </div>
 
-                <div className="mt-4">
-                  <h2 className="text-2xl font-bold mt-4 mb-2">Tested on</h2>
-                  <PlatformSupport
-                    platforms={versionInfo.moduleInfo.supportedPlatforms || []}
-                  />
-                  <BazelVersionSupport
-                    versions={
-                      versionInfo.moduleInfo.supportedBazelVersions || []
-                    }
-                  />
-                </div>
+              <div className="mt-4">
+                <h2 className="text-2xl font-bold mt-4 mb-2">Tested on</h2>
+                <PlatformSupport
+                  platforms={versionInfo.moduleInfo.supportedPlatforms || []}
+                />
+                <BazelVersionSupport
+                  versions={versionInfo.moduleInfo.supportedBazelVersions || []}
+                />
+              </div>
 
-                <h2 className="text-2xl font-bold mt-4 mb-2">Maintainers</h2>
-                <div>
-                  <ul>
-                    {metadata.maintainers?.map(({ name, email, github }) => (
-                      <li key={name} className="ml-1.5">
-                        <span className="flex">
-                          {email && (
-                            <a
-                              className="text-black hover:text-green-800 hover:scale-125 cursor-pointer mr-1"
-                              href={`mailto:${email}`}
-                            >
-                              <FontAwesomeIcon icon={faEnvelope} />
-                            </a>
-                          )}
-                          {github && (
-                            <a
-                              className="text-black hover:text-green-600 hover:scale-125 cursor-pointer mr-1"
-                              href={`https://github.com/${github}`}
-                            >
-                              <FontAwesomeIcon icon={faGithub} />
-                            </a>
-                          )}
-                          {name}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+              <h2 className="text-2xl font-bold mt-4 mb-2">Maintainers</h2>
+              <div>
+                <ul>
+                  {metadata.maintainers?.map(({ name, email, github }) => (
+                    <li key={name} className="ml-1.5">
+                      <span className="flex">
+                        {email && (
+                          <a
+                            className="text-black hover:text-green-800 hover:scale-125 cursor-pointer mr-1"
+                            href={`mailto:${email}`}
+                          >
+                            <FontAwesomeIcon icon={faEnvelope} />
+                          </a>
+                        )}
+                        {github && (
+                          <a
+                            className="text-black hover:text-green-600 hover:scale-125 cursor-pointer mr-1"
+                            href={`https://github.com/${github}`}
+                          >
+                            <FontAwesomeIcon icon={faGithub} />
+                          </a>
+                        )}
+                        {name}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
               </div>
             </div>
           </div>
         </div>
+        {versionInfo.stardocs.length > 0 && (
+          <div className="mt-6">
+            <h2 className="text-2xl font-bold mb-4">
+              Starlark API Documentation
+            </h2>
+            <div className="space-y-4">
+              {versionInfo.stardocs.map((stardoc, index) => (
+                <StardocRenderer
+                  key={stardoc.file || index}
+                  stardoc={stardoc}
+                  fileName={stardoc.file}
+                />
+              ))}
+            </div>
+          </div>
+        )}
       </main>
       <div className="flex-grow" />
       <Footer />

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -20,6 +20,7 @@ import {
 import { GithubRepositoryMetadata } from '../../data/githubMetadata'
 import { formatDistance, parseISO } from 'date-fns'
 import { faGlobe, faScaleBalanced } from '@fortawesome/free-solid-svg-icons'
+import { ModuleInfo as StardocModuleInfo } from '@buf/bazel_bazel.bufbuild_es/src/main/java/com/google/devtools/build/skydoc/rendering/proto/stardoc_output_pb.js'
 
 interface ModulePageProps {
   metadata: Metadata
@@ -366,7 +367,8 @@ const ModulePage: NextPage<ModulePageProps> = ({
                     )}
                   </details>
                 </div>
-                {versionInfo.binaryprotoFiles.length > 0 && (
+
+                {versionInfo.stardocs.length > 0 && (
                   <div className="mt-4">
                     <details>
                       <summary>
@@ -376,17 +378,17 @@ const ModulePage: NextPage<ModulePageProps> = ({
                           className="text-1xl mt-4"
                         >
                           <span className="font-bold">Documentation Files</span>{' '}
-                          ({versionInfo.binaryprotoFiles.length})
+                          ({versionInfo.stardocs.length})
                         </span>
                       </summary>
                       <ul className="mt-4">
-                        {versionInfo.binaryprotoFiles.map((file) => (
+                        {versionInfo.stardocs.map((moduleInfo) => (
                           <li
-                            key={file}
+                            key={moduleInfo}
                             className="border rounded p-2 mt-2 flex items-center gap-4"
                           >
                             <div className="font-mono text-sm text-gray-700">
-                              {file}
+                              {moduleInfo}
                             </div>
                           </li>
                         ))}

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -20,7 +20,8 @@ import {
 import { GithubRepositoryMetadata } from '../../data/githubMetadata'
 import { formatDistance, parseISO } from 'date-fns'
 import { faGlobe, faScaleBalanced } from '@fortawesome/free-solid-svg-icons'
-import { ModuleInfo as StardocModuleInfo } from '@buf/bazel_bazel.bufbuild_es/src/main/java/com/google/devtools/build/skydoc/rendering/proto/stardoc_output_pb.js'
+import { StardocModuleInfo } from '../../data/stardoc'
+import ReactMarkdown from 'react-markdown'
 
 interface ModulePageProps {
   metadata: Metadata
@@ -370,30 +371,38 @@ const ModulePage: NextPage<ModulePageProps> = ({
 
                 {versionInfo.stardocs.length > 0 && (
                   <div className="mt-4">
-                    <details>
-                      <summary>
-                        <span
-                          role="heading"
-                          aria-level={2}
-                          className="text-1xl mt-4"
+                    <h2 className="text-2xl font-bold mt-4">
+                      Starlark API Documentation
+                    </h2>
+                    {versionInfo.stardocs.map(
+                      (moduleInfo: StardocModuleInfo) => (
+                        <li
+                          key={moduleInfo.file}
+                          className="border rounded p-2 mt-2 flex items-center gap-4"
                         >
-                          <span className="font-bold">Documentation Files</span>{' '}
-                          ({versionInfo.stardocs.length})
-                        </span>
-                      </summary>
-                      <ul className="mt-4">
-                        {versionInfo.stardocs.map((moduleInfo) => (
-                          <li
-                            key={moduleInfo}
-                            className="border rounded p-2 mt-2 flex items-center gap-4"
-                          >
-                            <div className="font-mono text-sm text-gray-700">
-                              {moduleInfo}
-                            </div>
-                          </li>
-                        ))}
-                      </ul>
-                    </details>
+                          <details>
+                            <summary>
+                              <span
+                                role="heading"
+                                aria-level={2}
+                                className="text-1xl mt-4"
+                              >
+                                <span className="font-bold font-mono">
+                                  {moduleInfo.file}
+                                </span>
+                              </span>
+                            </summary>
+                            <ul className="mt-4">
+                              <div className="text-sm text-gray-700">
+                                <ReactMarkdown>
+                                  {moduleInfo.moduleDocstring}
+                                </ReactMarkdown>
+                              </div>
+                            </ul>
+                          </details>
+                        </li>
+                      )
+                    )}
                   </div>
                 )}
               </div>

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -12,7 +12,6 @@ import { CopyCode } from '../../components/CopyCode'
 import { AttestationBadge } from '../../components/AttestationBadge'
 import { PlatformSupport } from '../../components/PlatformSupport'
 import { BazelVersionSupport } from '../../components/BazelVersionSupport'
-import { StardocRenderer } from '../../components/Stardoc'
 import React, { useEffect, useState } from 'react'
 import {
   getStaticPropsModulePage,
@@ -21,6 +20,7 @@ import {
 import { GithubRepositoryMetadata } from '../../data/githubMetadata'
 import { formatDistance, parseISO } from 'date-fns'
 import { faGlobe, faScaleBalanced } from '@fortawesome/free-solid-svg-icons'
+import { StardocRenderer } from '../../components/Stardoc'
 
 interface ModulePageProps {
   metadata: Metadata
@@ -115,387 +115,398 @@ const ModulePage: NextPage<ModulePageProps> = ({
 
       <Header />
       <main>
-        <div className="border rounded p-4 divide-y">
-          <div className="flex items-center gap-1">
-            {versionInfo.hasAttestationFile && (
-              <span className="w-7 h-7 inline-block">
-                <AttestationBadge
-                  hasAttestationFile={true}
-                  placement="bottom-start"
-                />
+        <div className="max-w-7xl w-7xl mx-auto mt-8">
+          <div className="border rounded p-4 divide-y">
+            <div className="flex items-center gap-1">
+              {versionInfo.hasAttestationFile && (
+                <span className="w-7 h-7 inline-block">
+                  <AttestationBadge
+                    hasAttestationFile={true}
+                    placement="bottom-start"
+                  />
+                </span>
+              )}
+              <span
+                role="heading"
+                aria-level={1}
+                className="text-3xl translate-y-[-3px]"
+              >
+                {module}
               </span>
-            )}
-            <span
-              role="heading"
-              aria-level={1}
-              className="text-3xl translate-y-[-3px]"
-            >
-              {module}
-            </span>
-            <span className="text-lg ml-2">{selectedVersion}</span>
-          </div>
-          <div className="mt-4 flex flex-col md:flex-row flex-wrap sm:divide-x gap-2">
-            <div id="install_history_dependencies" className="basis-0 grow">
-              <h2 className="text-2xl font-bold mt-4">Install</h2>
-              <div className="mt-2">
-                <p>
-                  To start using this module, make sure you have set up Bzlmod
-                  according to the <a href={USER_GUIDE_LINK}>user guide</a>, and
-                  add the following to your <code>MODULE.bazel</code> file:
-                </p>
-                <CopyCode
-                  code={`bazel_dep(name = "${module}", version = "${selectedVersion}")`}
-                />
-                {!!releaseNotesLink && (
-                  <p>
-                    Read the{' '}
-                    <a
-                      href={releaseNotesLink}
-                      className="text-link-color hover:text-link-color-hover"
-                    >
-                      Release Notes
-                    </a>
-                  </p>
-                )}
-              </div>
-              <h2 className="text-2xl font-bold mt-4">Version history</h2>
-              <div>
-                <ul className="mt-4">
-                  {shownVersions.map((version) => (
-                    <>
-                      <li
-                        key={version.version}
-                        className="border rounded mt-2 "
-                      >
-                        {version.isYanked && (
-                          <div
-                            key={`${version.version}-yanked`}
-                            className="p-2 mb-2 bg-amber-300"
-                          >
-                            <a
-                              href="https://bazel.build/external/module#yanked_versions"
-                              className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
-                            >
-                              Version yanked
-                            </a>{' '}
-                            with comment: <p>{version.yankReason}</p>
-                          </div>
-                        )}
-                        <div className="flex items-stretch gap-4">
-                          <div className="flex flex-1 justify-between">
-                            <div className="flex p-2 flex-col gap-2 justify-between border-r hover:border-link-color hover:border-r-4">
-                              <Link
-                                href={`/modules/${module}/${version.version}`}
-                              >
-                                <div className="place-items-center hover:border-gray-800 flex items-center gap-2">
-                                  {version.version}
-                                  <AttestationBadge
-                                    hasAttestationFile={
-                                      version.hasAttestationFile
-                                    }
-                                  />
-                                </div>
-                              </Link>
-                              <div className="self-end text-gray-500">
-                                <a
-                                  href="https://bazel.build/external/module#compatibility_level"
-                                  className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
-                                >
-                                  compatibility level
-                                </a>{' '}
-                                {version.moduleInfo.compatibilityLevel}
-                              </div>
-                            </div>
-                            <div className="flex p-2 justify-end">
-                              <div className="flex flex-col justify-between items-end">
-                                <a
-                                  href={`https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/${module}/${version.version}`}
-                                  className="text-link-color hover:text-link-color-hover"
-                                >
-                                  view registry source
-                                </a>
-                                <a
-                                  href={`https://github.com/bazelbuild/bazel-central-registry/commit/${version.submission.hash}`}
-                                  className="text-link-color hover:text-link-color-hover"
-                                  suppressHydrationWarning
-                                >
-                                  published{' '}
-                                  {formatDistance(
-                                    parseISO(version.submission.authorDateIso),
-                                    new Date(),
-                                    { addSuffix: true }
-                                  )}
-                                </a>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </li>
-                    </>
-                  ))}
-                </ul>
-                {displayShowAllVersionsButton && (
-                  <button
-                    className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
-                    onClick={() => setTriggeredShowAllVersions(true)}
-                  >
-                    Show all {versionInfos.length} versions
-                  </button>
-                )}
-              </div>
-              <div className="mt-4">
-                <h2 className="text-2xl font-bold mt-4">Dependency graph</h2>
-              </div>
-              <div className="mt-4">
-                <details open>
-                  <summary>
-                    <span
-                      role="heading"
-                      aria-level={2}
-                      className="text-1xl mt-4"
-                    >
-                      <span className="font-bold">Direct</span> (
-                      {versionInfo.moduleInfo.dependencies.filter((d) => !d.dev)
-                        .length || 'None'}
-                      ){' '}
-                      <small className="text-sm font-normal text-gray-500">
-                        at version {selectedVersion}
-                      </small>
-                    </span>
-                  </summary>
-                  <ul className="mt-4">
-                    {versionInfo.moduleInfo.dependencies
-                      .filter((d) => !d.dev)
-                      .map((dependency) => (
-                        <Link
-                          key={dependency.module}
-                          href={`/modules/${dependency.module}/${dependency.version}`}
-                        >
-                          <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
-                            <div className="rounded-full border h-14 w-14 grid place-items-center">
-                              {dependency.version}
-                            </div>
-                            <div>{dependency.module}</div>
-                          </li>
-                        </Link>
-                      ))}
-                    {versionInfo.moduleInfo.dependencies.filter((d) => !d.dev)
-                      .length === 0 && <span>No dependencies</span>}
-                  </ul>
-                </details>
-              </div>
-              <div className="mt-4">
-                <details>
-                  <summary>
-                    <span
-                      role="heading"
-                      aria-level={2}
-                      className="text-1xl mt-4"
-                    >
-                      <span className="font-bold">Dev Dependencies</span> (
-                      {versionInfo.moduleInfo.dependencies.filter((d) => d.dev)
-                        .length || 'None'}
-                      ){' '}
-                    </span>
-                  </summary>
-                  <ul className="mt-4">
-                    {versionInfo.moduleInfo.dependencies
-                      .filter((d) => d.dev)
-                      .map((dependency) => (
-                        <Link
-                          key={dependency.module}
-                          href={`/modules/${dependency.module}/${dependency.version}`}
-                        >
-                          <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
-                            <div className="rounded-full border h-14 w-14 grid place-items-center">
-                              {dependency.version}
-                            </div>
-                            <div>{dependency.module}</div>
-                          </li>
-                        </Link>
-                      ))}
-                    {versionInfo.moduleInfo.dependencies.length === 0 && (
-                      <span>No dependencies</span>
-                    )}
-                  </ul>
-                </details>
-              </div>
-              <div className="mt-4">
-                <details>
-                  <summary>
-                    <span
-                      role="heading"
-                      aria-level={2}
-                      className="text-1xl mt-4"
-                    >
-                      <span className="font-bold">Dependents</span>{' '}
-                      {reverseDependencies.length > 0
-                        ? `(${reverseDependencies.length})`
-                        : ''}
-                    </span>
-                  </summary>
-                  <ul className="mt-4">
-                    {shownReverseDependencies.map((revDependency) => (
-                      <Link
-                        key={revDependency}
-                        href={`/modules/${revDependency}`}
-                      >
-                        <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
-                          <div>{revDependency}</div>
-                        </li>
-                      </Link>
-                    ))}
-                    {reverseDependencies.length === 0 && (
-                      <span>No dependent modules yet</span>
-                    )}
-                  </ul>
-                  {displayShowAllReverseDependenciesButton && (
-                    <button
-                      className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
-                      onClick={() =>
-                        setTriggeredShowAllReverseDependencies(true)
-                      }
-                    >
-                      Show all {reverseDependencies.length} dependent modules
-                    </button>
-                  )}
-                </details>
-              </div>
+              <span className="text-lg ml-2">{selectedVersion}</span>
             </div>
-            <div id="metadata" className="sm:pl-2 basis-8 md:basis-[12rem]">
-              <h2 className="text-2xl font-bold mt-4 mb-2">About</h2>
-              <div>
-                {repoDescription && (
-                  <div className="mb-2">
-                    <p className="text-md">{repoDescription}</p>
-                  </div>
-                )}
-                <div className="space-y-1">
-                  {repoTopics && (
-                    <div className="mb-4 mt-4 flex flex-row flex-wrap gap-1">
-                      {repoTopics.map((topic) => {
-                        return (
-                          <span
-                            className="rounded-xl pl-3 pr-3 pt-0.5 pb-0.5 font-semibold mr-1 text-sm text-[#0b713b] bg-[#0b713b1a]"
-                            key={topic}
-                          >
-                            {topic}
-                          </span>
-                        )
-                      })}
-                    </div>
-                  )}
-
-                  {metadata.homepage !== githubLink ? (
-                    <a
-                      href={metadata.homepage}
-                      className="block text-link-color hover:text-link-color-hover"
-                      title={metadata.homepage}
-                    >
-                      <FontAwesomeIcon
-                        icon={faGlobe}
-                        className="mr-1 min-w-[30px]"
-                      />
-                      Homepage
-                    </a>
-                  ) : null}
-
-                  {repoStargazers && (
-                    <div className="text-black">
-                      <FontAwesomeIcon
-                        className="mr-1 min-w-[30px]"
-                        icon={faStar}
-                      />
-                      {repoStargazers} Stars
-                    </div>
-                  )}
-
-                  {repoLicense && (
-                    <a
-                      href={repoLicense.url}
-                      className="block text-link-color hover:text-link-color-hover cursor-pointer"
-                      title={repoLicense.spdx_id}
-                    >
-                      <FontAwesomeIcon
-                        className="mr-1 min-w-[30px]"
-                        icon={faScaleBalanced}
-                      />
-                      {repoLicense.name}
-                    </a>
-                  )}
-
-                  {githubLink && (
-                    <div>
+            <div className="mt-4 flex flex-col md:flex-row flex-wrap sm:divide-x gap-2">
+              <div id="install_history_dependencies" className="basis-0 grow">
+                <h2 className="text-2xl font-bold mt-4">Install</h2>
+                <div className="mt-2">
+                  <p>
+                    To start using this module, make sure you have set up Bzlmod
+                    according to the <a href={USER_GUIDE_LINK}>user guide</a>,
+                    and add the following to your <code>MODULE.bazel</code>{' '}
+                    file:
+                  </p>
+                  <CopyCode
+                    code={`bazel_dep(name = "${module}", version = "${selectedVersion}")`}
+                  />
+                  {!!releaseNotesLink && (
+                    <p>
+                      Read the{' '}
                       <a
-                        href={githubLink}
+                        href={releaseNotesLink}
                         className="text-link-color hover:text-link-color-hover"
-                        title={githubLink}
                       >
-                        <FontAwesomeIcon
-                          icon={faGithub}
-                          className="mr-1 min-w-[30px]"
-                        />
-                        GitHub repository
+                        Release Notes
                       </a>
-                    </div>
+                    </p>
                   )}
                 </div>
-              </div>
-
-              <div className="mt-4">
-                <h2 className="text-2xl font-bold mt-4 mb-2">Tested on</h2>
-                <PlatformSupport
-                  platforms={versionInfo.moduleInfo.supportedPlatforms || []}
-                />
-                <BazelVersionSupport
-                  versions={versionInfo.moduleInfo.supportedBazelVersions || []}
-                />
-              </div>
-
-              <h2 className="text-2xl font-bold mt-4 mb-2">Maintainers</h2>
-              <div>
-                <ul>
-                  {metadata.maintainers?.map(({ name, email, github }) => (
-                    <li key={name} className="ml-1.5">
-                      <span className="flex">
-                        {email && (
-                          <a
-                            className="text-black hover:text-green-800 hover:scale-125 cursor-pointer mr-1"
-                            href={`mailto:${email}`}
-                          >
-                            <FontAwesomeIcon icon={faEnvelope} />
-                          </a>
-                        )}
-                        {github && (
-                          <a
-                            className="text-black hover:text-green-600 hover:scale-125 cursor-pointer mr-1"
-                            href={`https://github.com/${github}`}
-                          >
-                            <FontAwesomeIcon icon={faGithub} />
-                          </a>
-                        )}
-                        {name}
+                <h2 className="text-2xl font-bold mt-4">Version history</h2>
+                <div>
+                  <ul className="mt-4">
+                    {shownVersions.map((version) => (
+                      <>
+                        <li
+                          key={version.version}
+                          className="border rounded mt-2 "
+                        >
+                          {version.isYanked && (
+                            <div
+                              key={`${version.version}-yanked`}
+                              className="p-2 mb-2 bg-amber-300"
+                            >
+                              <a
+                                href="https://bazel.build/external/module#yanked_versions"
+                                className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
+                              >
+                                Version yanked
+                              </a>{' '}
+                              with comment: <p>{version.yankReason}</p>
+                            </div>
+                          )}
+                          <div className="flex items-stretch gap-4">
+                            <div className="flex flex-1 justify-between">
+                              <div className="flex p-2 flex-col gap-2 justify-between border-r hover:border-link-color hover:border-r-4">
+                                <Link
+                                  href={`/modules/${module}/${version.version}`}
+                                >
+                                  <div className="place-items-center hover:border-gray-800 flex items-center gap-2">
+                                    {version.version}
+                                    <AttestationBadge
+                                      hasAttestationFile={
+                                        version.hasAttestationFile
+                                      }
+                                    />
+                                  </div>
+                                </Link>
+                                <div className="self-end text-gray-500">
+                                  <a
+                                    href="https://bazel.build/external/module#compatibility_level"
+                                    className="underline decoration-dashed decoration-gray-500 hover:decoration-black"
+                                  >
+                                    compatibility level
+                                  </a>{' '}
+                                  {version.moduleInfo.compatibilityLevel}
+                                </div>
+                              </div>
+                              <div className="flex p-2 justify-end">
+                                <div className="flex flex-col justify-between items-end">
+                                  <a
+                                    href={`https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/${module}/${version.version}`}
+                                    className="text-link-color hover:text-link-color-hover"
+                                  >
+                                    view registry source
+                                  </a>
+                                  <a
+                                    href={`https://github.com/bazelbuild/bazel-central-registry/commit/${version.submission.hash}`}
+                                    className="text-link-color hover:text-link-color-hover"
+                                    suppressHydrationWarning
+                                  >
+                                    published{' '}
+                                    {formatDistance(
+                                      parseISO(
+                                        version.submission.authorDateIso
+                                      ),
+                                      new Date(),
+                                      { addSuffix: true }
+                                    )}
+                                  </a>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      </>
+                    ))}
+                  </ul>
+                  {displayShowAllVersionsButton && (
+                    <button
+                      className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
+                      onClick={() => setTriggeredShowAllVersions(true)}
+                    >
+                      Show all {versionInfos.length} versions
+                    </button>
+                  )}
+                </div>
+                <div className="mt-4">
+                  <h2 className="text-2xl font-bold mt-4">Dependency graph</h2>
+                </div>
+                <div className="mt-4">
+                  <details open>
+                    <summary>
+                      <span
+                        role="heading"
+                        aria-level={2}
+                        className="text-1xl mt-4"
+                      >
+                        <span className="font-bold">Direct</span> (
+                        {versionInfo.moduleInfo.dependencies.filter(
+                          (d) => !d.dev
+                        ).length || 'None'}
+                        ){' '}
+                        <small className="text-sm font-normal text-gray-500">
+                          at version {selectedVersion}
+                        </small>
                       </span>
-                    </li>
-                  ))}
-                </ul>
+                    </summary>
+                    <ul className="mt-4">
+                      {versionInfo.moduleInfo.dependencies
+                        .filter((d) => !d.dev)
+                        .map((dependency) => (
+                          <Link
+                            key={dependency.module}
+                            href={`/modules/${dependency.module}/${dependency.version}`}
+                          >
+                            <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
+                              <div className="rounded-full border h-14 w-14 grid place-items-center">
+                                {dependency.version}
+                              </div>
+                              <div>{dependency.module}</div>
+                            </li>
+                          </Link>
+                        ))}
+                      {versionInfo.moduleInfo.dependencies.filter((d) => !d.dev)
+                        .length === 0 && <span>No dependencies</span>}
+                    </ul>
+                  </details>
+                </div>
+                <div className="mt-4">
+                  <details>
+                    <summary>
+                      <span
+                        role="heading"
+                        aria-level={2}
+                        className="text-1xl mt-4"
+                      >
+                        <span className="font-bold">Dev Dependencies</span> (
+                        {versionInfo.moduleInfo.dependencies.filter(
+                          (d) => d.dev
+                        ).length || 'None'}
+                        ){' '}
+                      </span>
+                    </summary>
+                    <ul className="mt-4">
+                      {versionInfo.moduleInfo.dependencies
+                        .filter((d) => d.dev)
+                        .map((dependency) => (
+                          <Link
+                            key={dependency.module}
+                            href={`/modules/${dependency.module}/${dependency.version}`}
+                          >
+                            <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
+                              <div className="rounded-full border h-14 w-14 grid place-items-center">
+                                {dependency.version}
+                              </div>
+                              <div>{dependency.module}</div>
+                            </li>
+                          </Link>
+                        ))}
+                      {versionInfo.moduleInfo.dependencies.length === 0 && (
+                        <span>No dependencies</span>
+                      )}
+                    </ul>
+                  </details>
+                </div>
+                <div className="mt-4">
+                  <details>
+                    <summary>
+                      <span
+                        role="heading"
+                        aria-level={2}
+                        className="text-1xl mt-4"
+                      >
+                        <span className="font-bold">Dependents</span>{' '}
+                        {reverseDependencies.length > 0
+                          ? `(${reverseDependencies.length})`
+                          : ''}
+                      </span>
+                    </summary>
+                    <ul className="mt-4">
+                      {shownReverseDependencies.map((revDependency) => (
+                        <Link
+                          key={revDependency}
+                          href={`/modules/${revDependency}`}
+                        >
+                          <li className="border rounded p-2 mt-2 flex items-center gap-4 hover:border-gray-800">
+                            <div>{revDependency}</div>
+                          </li>
+                        </Link>
+                      ))}
+                      {reverseDependencies.length === 0 && (
+                        <span>No dependent modules yet</span>
+                      )}
+                    </ul>
+                    {displayShowAllReverseDependenciesButton && (
+                      <button
+                        className="font-semibold border rounded p-2 mt-4 w-full hover:shadow-lg"
+                        onClick={() =>
+                          setTriggeredShowAllReverseDependencies(true)
+                        }
+                      >
+                        Show all {reverseDependencies.length} dependent modules
+                      </button>
+                    )}
+                  </details>
+                </div>
+              </div>
+              <div id="metadata" className="sm:pl-2 basis-8 md:basis-[12rem]">
+                <h2 className="text-2xl font-bold mt-4 mb-2">About</h2>
+                <div>
+                  {repoDescription && (
+                    <div className="mb-2">
+                      <p className="text-md">{repoDescription}</p>
+                    </div>
+                  )}
+                  <div className="space-y-1">
+                    {repoTopics && (
+                      <div className="mb-4 mt-4 flex flex-row flex-wrap gap-1">
+                        {repoTopics.map((topic) => {
+                          return (
+                            <span
+                              className="rounded-xl pl-3 pr-3 pt-0.5 pb-0.5 font-semibold mr-1 text-sm text-[#0b713b] bg-[#0b713b1a]"
+                              key={topic}
+                            >
+                              {topic}
+                            </span>
+                          )
+                        })}
+                      </div>
+                    )}
+
+                    {metadata.homepage !== githubLink ? (
+                      <a
+                        href={metadata.homepage}
+                        className="block text-link-color hover:text-link-color-hover"
+                        title={metadata.homepage}
+                      >
+                        <FontAwesomeIcon
+                          icon={faGlobe}
+                          className="mr-1 min-w-[30px]"
+                        />
+                        Homepage
+                      </a>
+                    ) : null}
+
+                    {repoStargazers && (
+                      <div className="text-black">
+                        <FontAwesomeIcon
+                          className="mr-1 min-w-[30px]"
+                          icon={faStar}
+                        />
+                        {repoStargazers} Stars
+                      </div>
+                    )}
+
+                    {repoLicense && (
+                      <a
+                        href={repoLicense.url}
+                        className="block text-link-color hover:text-link-color-hover cursor-pointer"
+                        title={repoLicense.spdx_id}
+                      >
+                        <FontAwesomeIcon
+                          className="mr-1 min-w-[30px]"
+                          icon={faScaleBalanced}
+                        />
+                        {repoLicense.name}
+                      </a>
+                    )}
+
+                    {githubLink && (
+                      <div>
+                        <a
+                          href={githubLink}
+                          className="text-link-color hover:text-link-color-hover"
+                          title={githubLink}
+                        >
+                          <FontAwesomeIcon
+                            icon={faGithub}
+                            className="mr-1 min-w-[30px]"
+                          />
+                          GitHub repository
+                        </a>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="mt-4">
+                  <h2 className="text-2xl font-bold mt-4 mb-2">Tested on</h2>
+                  <PlatformSupport
+                    platforms={versionInfo.moduleInfo.supportedPlatforms || []}
+                  />
+                  <BazelVersionSupport
+                    versions={
+                      versionInfo.moduleInfo.supportedBazelVersions || []
+                    }
+                  />
+                </div>
+
+                <h2 className="text-2xl font-bold mt-4 mb-2">Maintainers</h2>
+                <div>
+                  <ul>
+                    {metadata.maintainers?.map(({ name, email, github }) => (
+                      <li key={name} className="ml-1.5">
+                        <span className="flex">
+                          {email && (
+                            <a
+                              className="text-black hover:text-green-800 hover:scale-125 cursor-pointer mr-1"
+                              href={`mailto:${email}`}
+                            >
+                              <FontAwesomeIcon icon={faEnvelope} />
+                            </a>
+                          )}
+                          {github && (
+                            <a
+                              className="text-black hover:text-green-600 hover:scale-125 cursor-pointer mr-1"
+                              href={`https://github.com/${github}`}
+                            >
+                              <FontAwesomeIcon icon={faGithub} />
+                            </a>
+                          )}
+                          {name}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </div>
             </div>
           </div>
         </div>
         {versionInfo.stardocs.length > 0 && (
-          <div className="mt-6">
-            <h2 className="text-2xl font-bold mb-4">
-              Starlark API Documentation
-            </h2>
-            <div className="space-y-4">
-              {versionInfo.stardocs.map((stardoc, index) => (
-                <StardocRenderer
-                  key={stardoc.file || index}
-                  stardoc={stardoc}
-                  fileName={stardoc.file}
-                />
-              ))}
+          <div className="max-w-7xl w-7xl mx-auto mt-8">
+            <div className="mt-6">
+              <h2 className="text-2xl font-bold mb-4">
+                Starlark API Documentation
+              </h2>
+              <div className="space-y-4">
+                {versionInfo.stardocs.map((stardoc, index) => (
+                  <StardocRenderer
+                    key={stardoc.file || index}
+                    stardoc={stardoc}
+                    fileName={stardoc.file}
+                  />
+                ))}
+              </div>
             </div>
           </div>
         )}

--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -503,7 +503,6 @@ const ModulePage: NextPage<ModulePageProps> = ({
                   <StardocRenderer
                     key={stardoc.file || index}
                     stardoc={stardoc}
-                    fileName={stardoc.file}
                   />
                 ))}
               </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,12 @@ importers:
 
   .:
     dependencies:
+      '@buf/bazel_bazel.bufbuild_es':
+        specifier: 2.0.0-20240806194025-8f5cf9629ba6.1
+        version: 2.0.0-20240806194025-8f5cf9629ba6.1(@bufbuild/protobuf@2.9.0)
+      '@bufbuild/protobuf':
+        specifier: ^2
+        version: 2.9.0
       '@floating-ui/react-dom':
         specifier: ^2.0.0
         version: 2.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -100,6 +106,29 @@ packages:
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
+
+  '@buf/bazel_bazel.bufbuild_es@2.0.0-20240806194025-8f5cf9629ba6.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/bazel_bazel.bufbuild_es/-/bazel_bazel.bufbuild_es-2.0.0-20240806194025-8f5cf9629ba6.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/bazel_remote-apis.bufbuild_es@2.0.0-20230602030542-b202931f28c0.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/bazel_remote-apis.bufbuild_es/-/bazel_remote-apis.bufbuild_es-2.0.0-20230602030542-b202931f28c0.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20230502210827-cc916c318597.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.0.0-20230502210827-cc916c318597.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20240729201550-8bc2c51e08c4.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.0.0-20240729201550-8bc2c51e08c4.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@bufbuild/protobuf@2.9.0':
+    resolution: {integrity: sha512-rnJenoStJ8nvmt9Gzye8nkYd6V22xUAnu4086ER7h1zJ508vStko4pMvDeQ446ilDTFpV5wnoc5YS7XvMwwMqA==}
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -1992,6 +2021,27 @@ packages:
 snapshots:
 
   '@babel/runtime@7.28.4': {}
+
+  '@buf/bazel_bazel.bufbuild_es@2.0.0-20240806194025-8f5cf9629ba6.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@buf/bazel_remote-apis.bufbuild_es': 2.0.0-20230602030542-b202931f28c0.1(@bufbuild/protobuf@2.9.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 2.0.0-20240729201550-8bc2c51e08c4.1(@bufbuild/protobuf@2.9.0)
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/bazel_remote-apis.bufbuild_es@2.0.0-20230602030542-b202931f28c0.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@buf/googleapis_googleapis.bufbuild_es': 2.0.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@2.9.0)
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20240729201550-8bc2c51e08c4.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.9.0
+
+  '@bufbuild/protobuf@2.9.0': {}
 
   '@emnapi/core@1.5.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,12 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.6.6
         version: 15.6.6(react@19.1.1)
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwindcss:
         specifier: ~3.1.3
         version: 3.1.8(postcss@8.4.31)
@@ -1084,6 +1090,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-config-next@15.5.3:
     resolution: {integrity: sha512-e6j+QhQFOr5pfsc8VJbuTD9xTXJaRvMHYjEeLPA2pFkheNlgPLCkxdvhxhfuM4KGcqSZj2qEnpHisdTVs3BxuQ==}
     peerDependencies:
@@ -1647,12 +1657,36 @@ packages:
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -1662,6 +1696,9 @@ packages:
 
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -1684,6 +1721,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -2053,11 +2111,20 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3426,6 +3493,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-config-next@15.5.3(eslint@8.53.0)(typescript@5.2.2):
     dependencies:
       '@next/eslint-plugin-next': 15.5.3
@@ -4111,7 +4180,16 @@ snapshots:
       fault: 1.0.4
       highlight.js: 10.7.3
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -4127,6 +4205,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4168,6 +4303,11 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
+
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
 
   mdast-util-phrasing@4.1.0:
     dependencies:
@@ -4223,6 +4363,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -4660,6 +4858,23 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4676,6 +4891,12 @@ snapshots:
       mdast-util-to-hast: 13.2.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   resolve-from@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       typescript:
         specifier: 5.2.2
         version: 5.2.2
+      zlib:
+        specifier: ^1.0.5
+        version: 1.0.5
 
 packages:
 
@@ -2093,6 +2096,10 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zlib@1.0.5:
+    resolution: {integrity: sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==}
+    engines: {node: '>=0.2.0'}
+
 snapshots:
 
   '@babel/runtime@7.28.4': {}
@@ -2149,7 +2156,13 @@ snapshots:
 
   '@buf/grpc_grpc.bufbuild_es@2.0.0-20230516211939-d8bc6b0fb32a.1(@bufbuild/protobuf@2.9.0)':
     dependencies:
+      '@buf/cncf_xds.bufbuild_es': 2.0.0-20230428204815-197fca8a74c5.1(@bufbuild/protobuf@2.9.0)
+      '@buf/envoyproxy_envoy.bufbuild_es': 2.0.0-20230516211932-3afde44c0a3a.1(@bufbuild/protobuf@2.9.0)
+      '@buf/envoyproxy_protoc-gen-validate.bufbuild_es': 2.0.0-20221025150516-6607b10f00ed.1(@bufbuild/protobuf@2.9.0)
       '@buf/googleapis_googleapis.bufbuild_es': 2.0.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@2.9.0)
+      '@buf/opencensus_opencensus.bufbuild_es': 2.0.0-20230503204408-7e4755513505.1(@bufbuild/protobuf@2.9.0)
+      '@buf/opentelemetry_opentelemetry.bufbuild_es': 2.0.0-20230516211923-547fa0c6b925.1(@bufbuild/protobuf@2.9.0)
+      '@buf/prometheus_client-model.bufbuild_es': 2.0.0-20230331140308-55bcfe88c9e5.1(@bufbuild/protobuf@2.9.0)
       '@bufbuild/protobuf': 2.9.0
 
   '@buf/opencensus_opencensus.bufbuild_es@2.0.0-20230503204408-7e4755513505.1(@bufbuild/protobuf@2.9.0)':
@@ -3039,8 +3052,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.53.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.53.0)
       eslint-plugin-react: 7.37.5(eslint@8.53.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.53.0)
@@ -3059,7 +3072,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.53.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -3070,22 +3083,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.53.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3096,7 +3109,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4340,3 +4353,5 @@ snapshots:
   yaml@1.10.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zlib@1.0.5: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       prettier:
         specifier: ^3.0.0
         version: 3.6.2
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.1.13)(react@19.1.1)
       tailwindcss:
         specifier: ~3.1.3
         version: 3.1.8(postcss@8.4.31)
@@ -468,11 +471,29 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@18.17.9':
     resolution: {integrity: sha512-fxaKquqYcPOGwE7tC1anJaPJ0GHyOVzfA2oUoXECjBjrtsIz4YJvtNYsq8LUcjEUehEF+jGpx8Z+lFrtT6z0tg==}
@@ -487,6 +508,12 @@ packages:
 
   '@types/tar-stream@3.1.4':
     resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.44.0':
     resolution: {integrity: sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==}
@@ -786,6 +813,9 @@ packages:
       react-native-b4a:
         optional: true
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -838,9 +868,24 @@ packages:
   caniuse-lite@1.0.30001741:
     resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -862,6 +907,9 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
@@ -917,6 +965,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.2.0:
+    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -931,6 +982,10 @@ packages:
   defined@1.0.1:
     resolution: {integrity: sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.0:
     resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
     engines: {node: '>=8'}
@@ -939,6 +994,9 @@ packages:
     resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1116,6 +1174,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1126,6 +1187,9 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1288,6 +1352,15 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
@@ -1315,9 +1388,18 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.4:
+    resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1361,6 +1443,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1376,6 +1461,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -1396,6 +1484,10 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -1496,6 +1588,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1504,12 +1599,99 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.0:
+    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1652,6 +1834,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1747,6 +1932,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1766,6 +1954,12 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': 19.1.13
+      react: '>=18'
+
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
@@ -1784,6 +1978,12 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1892,6 +2092,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -1925,6 +2128,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1940,6 +2146,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.17:
+    resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
+
+  style-to-object@1.0.9:
+    resolution: {integrity: sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1985,6 +2197,12 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
@@ -2041,6 +2259,24 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -2055,6 +2291,12 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2099,6 +2341,9 @@ packages:
   zlib@1.0.5:
     resolution: {integrity: sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==}
     engines: {node: '>=0.2.0'}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2420,9 +2665,29 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
+  '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/js-yaml@4.0.9': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@18.17.9': {}
 
@@ -2437,6 +2702,10 @@ snapshots:
   '@types/tar-stream@3.1.4':
     dependencies:
       '@types/node': 18.17.9
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0)(typescript@5.2.2)':
     dependencies:
@@ -2753,6 +3022,8 @@ snapshots:
 
   b4a@1.7.3: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   bare-events@2.7.0: {}
@@ -2805,10 +3076,20 @@ snapshots:
 
   caniuse-lite@1.0.30001741: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -2841,6 +3122,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
     optional: true
+
+  comma-separated-tokens@2.0.3: {}
 
   compare-versions@6.1.1: {}
 
@@ -2888,6 +3171,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.2.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -2904,6 +3191,8 @@ snapshots:
 
   defined@1.0.1: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.0:
     optional: true
 
@@ -2912,6 +3201,10 @@ snapshots:
       acorn-node: 1.8.2
       defined: 1.0.1
       minimist: 1.2.8
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   didyoumean@1.2.2: {}
 
@@ -3052,8 +3345,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.53.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.53.0)
       eslint-plugin-react: 7.37.5(eslint@8.53.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.53.0)
@@ -3072,7 +3365,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.53.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -3083,22 +3376,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.53.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3109,7 +3402,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.53.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3240,6 +3533,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   esutils@2.0.3: {}
 
   events-universal@1.0.1:
@@ -3257,6 +3552,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3435,6 +3732,32 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.17
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  html-url-attributes@3.0.1: {}
+
   human-signals@5.0.0: {}
 
   ignore@5.3.2: {}
@@ -3455,11 +3778,20 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.4: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -3512,6 +3844,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -3529,6 +3863,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -3541,6 +3877,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -3642,15 +3980,239 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.0
+
+  mdast-util-to-hast@13.2.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -3798,6 +4360,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.2.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -3867,6 +4439,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.1.0: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
@@ -3879,6 +4453,24 @@ snapshots:
       scheduler: 0.26.0
 
   react-is@16.13.1: {}
+
+  react-markdown@10.1.0(@types/react@19.1.13)(react@19.1.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.1.13
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.0
+      react: 19.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react@19.1.1: {}
 
@@ -3909,6 +4501,23 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.0
+      unified: 11.0.5
+      vfile: 6.0.3
 
   resolve-from@4.0.0: {}
 
@@ -4058,6 +4667,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stable-hash@0.0.5: {}
 
   stop-iteration-iterator@1.1.0:
@@ -4123,6 +4734,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -4132,6 +4748,14 @@ snapshots:
   strip-final-newline@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.17:
+    dependencies:
+      style-to-object: 1.0.9
+
+  style-to-object@1.0.9:
+    dependencies:
+      inline-style-parser: 0.2.4
 
   styled-jsx@5.1.6(react@19.1.1):
     dependencies:
@@ -4195,6 +4819,10 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@1.4.3(typescript@5.2.2):
     dependencies:
@@ -4263,6 +4891,39 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.3
@@ -4298,6 +4959,16 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4355,3 +5026,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zlib@1.0.5: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@types/react-dom':
         specifier: 19.1.9
         version: 19.1.9(@types/react@19.1.13)
+      '@types/react-syntax-highlighter':
+        specifier: ^15.5.13
+        version: 15.5.13
       autoprefixer:
         specifier: ^10.4.7
         version: 10.4.21(postcss@8.4.31)
@@ -514,6 +517,9 @@ packages:
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
     peerDependencies:
       '@types/react': 19.1.13
+
+  '@types/react-syntax-highlighter@15.5.13':
+    resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
 
   '@types/react@19.1.13':
     resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
@@ -2840,6 +2846,10 @@ snapshots:
   '@types/node@18.17.9': {}
 
   '@types/react-dom@19.1.9(@types/react@19.1.13)':
+    dependencies:
+      '@types/react': 19.1.13
+
+  '@types/react-syntax-highlighter@15.5.13':
     dependencies:
       '@types/react': 19.1.13
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@fortawesome/react-fontawesome':
         specifier: ^3.0.2
         version: 3.0.2(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.1.1)
+      '@types/tar-stream':
+        specifier: ^3.1.4
+        version: 3.1.4
       compare-versions:
         specifier: 6.1.1
         version: 6.1.1
@@ -66,6 +69,9 @@ importers:
       react-dom:
         specifier: 19.1.1
         version: 19.1.1(react@19.1.1)
+      tar-stream:
+        specifier: ^3.1.7
+        version: 3.1.7
     devDependencies:
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -117,6 +123,26 @@ packages:
     peerDependencies:
       '@bufbuild/protobuf': ^2.0.0
 
+  '@buf/cncf_xds.bufbuild_es@2.0.0-20230428204815-197fca8a74c5.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/cncf_xds.bufbuild_es/-/cncf_xds.bufbuild_es-2.0.0-20230428204815-197fca8a74c5.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/envoyproxy_envoy.bufbuild_es@2.0.0-20230516211932-3afde44c0a3a.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/envoyproxy_envoy.bufbuild_es/-/envoyproxy_envoy.bufbuild_es-2.0.0-20230516211932-3afde44c0a3a.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/envoyproxy_protoc-gen-validate.bufbuild_es@2.0.0-20221025150516-6607b10f00ed.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/envoyproxy_protoc-gen-validate.bufbuild_es/-/envoyproxy_protoc-gen-validate.bufbuild_es-2.0.0-20221025150516-6607b10f00ed.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20230329151039-5ae7f88519b0.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.0.0-20230329151039-5ae7f88519b0.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
   '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20230502210827-cc916c318597.1':
     resolution: {tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.0.0-20230502210827-cc916c318597.1.tgz}
     peerDependencies:
@@ -124,6 +150,26 @@ packages:
 
   '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20240729201550-8bc2c51e08c4.1':
     resolution: {tarball: https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-2.0.0-20240729201550-8bc2c51e08c4.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/grpc_grpc.bufbuild_es@2.0.0-20230516211939-d8bc6b0fb32a.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/grpc_grpc.bufbuild_es/-/grpc_grpc.bufbuild_es-2.0.0-20230516211939-d8bc6b0fb32a.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/opencensus_opencensus.bufbuild_es@2.0.0-20230503204408-7e4755513505.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/opencensus_opencensus.bufbuild_es/-/opencensus_opencensus.bufbuild_es-2.0.0-20230503204408-7e4755513505.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/opentelemetry_opentelemetry.bufbuild_es@2.0.0-20230516211923-547fa0c6b925.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/opentelemetry_opentelemetry.bufbuild_es/-/opentelemetry_opentelemetry.bufbuild_es-2.0.0-20230516211923-547fa0c6b925.1.tgz}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.0.0
+
+  '@buf/prometheus_client-model.bufbuild_es@2.0.0-20230331140308-55bcfe88c9e5.1':
+    resolution: {tarball: https://buf.build/gen/npm/v1/@buf/prometheus_client-model.bufbuild_es/-/prometheus_client-model.bufbuild_es-2.0.0-20230331140308-55bcfe88c9e5.1.tgz}
     peerDependencies:
       '@bufbuild/protobuf': ^2.0.0
 
@@ -436,6 +482,9 @@ packages:
   '@types/react@19.1.13':
     resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
 
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
+
   '@typescript-eslint/eslint-plugin@8.44.0':
     resolution: {integrity: sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -726,8 +775,19 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.7.3:
+    resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bare-events@2.7.0:
+    resolution: {integrity: sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==}
 
   baseline-browser-mapping@2.8.4:
     resolution: {integrity: sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==}
@@ -1057,12 +1117,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -1830,6 +1896,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamx@2.23.0:
+    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
     engines: {node: '>= 0.4'}
@@ -1896,6 +1965,12 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.0.9
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  text-decoder@1.2.3:
+    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -2030,7 +2105,38 @@ snapshots:
 
   '@buf/bazel_remote-apis.bufbuild_es@2.0.0-20230602030542-b202931f28c0.1(@bufbuild/protobuf@2.9.0)':
     dependencies:
+      '@buf/cncf_xds.bufbuild_es': 2.0.0-20230428204815-197fca8a74c5.1(@bufbuild/protobuf@2.9.0)
+      '@buf/envoyproxy_envoy.bufbuild_es': 2.0.0-20230516211932-3afde44c0a3a.1(@bufbuild/protobuf@2.9.0)
+      '@buf/envoyproxy_protoc-gen-validate.bufbuild_es': 2.0.0-20221025150516-6607b10f00ed.1(@bufbuild/protobuf@2.9.0)
       '@buf/googleapis_googleapis.bufbuild_es': 2.0.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@2.9.0)
+      '@buf/grpc_grpc.bufbuild_es': 2.0.0-20230516211939-d8bc6b0fb32a.1(@bufbuild/protobuf@2.9.0)
+      '@buf/opencensus_opencensus.bufbuild_es': 2.0.0-20230503204408-7e4755513505.1(@bufbuild/protobuf@2.9.0)
+      '@buf/opentelemetry_opentelemetry.bufbuild_es': 2.0.0-20230516211923-547fa0c6b925.1(@bufbuild/protobuf@2.9.0)
+      '@buf/prometheus_client-model.bufbuild_es': 2.0.0-20230331140308-55bcfe88c9e5.1(@bufbuild/protobuf@2.9.0)
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/cncf_xds.bufbuild_es@2.0.0-20230428204815-197fca8a74c5.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@buf/envoyproxy_protoc-gen-validate.bufbuild_es': 2.0.0-20221025150516-6607b10f00ed.1(@bufbuild/protobuf@2.9.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 2.0.0-20230329151039-5ae7f88519b0.1(@bufbuild/protobuf@2.9.0)
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/envoyproxy_envoy.bufbuild_es@2.0.0-20230516211932-3afde44c0a3a.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@buf/cncf_xds.bufbuild_es': 2.0.0-20230428204815-197fca8a74c5.1(@bufbuild/protobuf@2.9.0)
+      '@buf/envoyproxy_protoc-gen-validate.bufbuild_es': 2.0.0-20221025150516-6607b10f00ed.1(@bufbuild/protobuf@2.9.0)
+      '@buf/googleapis_googleapis.bufbuild_es': 2.0.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@2.9.0)
+      '@buf/opencensus_opencensus.bufbuild_es': 2.0.0-20230503204408-7e4755513505.1(@bufbuild/protobuf@2.9.0)
+      '@buf/opentelemetry_opentelemetry.bufbuild_es': 2.0.0-20230516211923-547fa0c6b925.1(@bufbuild/protobuf@2.9.0)
+      '@buf/prometheus_client-model.bufbuild_es': 2.0.0-20230331140308-55bcfe88c9e5.1(@bufbuild/protobuf@2.9.0)
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/envoyproxy_protoc-gen-validate.bufbuild_es@2.0.0-20221025150516-6607b10f00ed.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20230329151039-5ae7f88519b0.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
       '@bufbuild/protobuf': 2.9.0
 
   '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@2.9.0)':
@@ -2038,6 +2144,23 @@ snapshots:
       '@bufbuild/protobuf': 2.9.0
 
   '@buf/googleapis_googleapis.bufbuild_es@2.0.0-20240729201550-8bc2c51e08c4.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/grpc_grpc.bufbuild_es@2.0.0-20230516211939-d8bc6b0fb32a.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@buf/googleapis_googleapis.bufbuild_es': 2.0.0-20230502210827-cc916c318597.1(@bufbuild/protobuf@2.9.0)
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/opencensus_opencensus.bufbuild_es@2.0.0-20230503204408-7e4755513505.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/opentelemetry_opentelemetry.bufbuild_es@2.0.0-20230516211923-547fa0c6b925.1(@bufbuild/protobuf@2.9.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.9.0
+
+  '@buf/prometheus_client-model.bufbuild_es@2.0.0-20230331140308-55bcfe88c9e5.1(@bufbuild/protobuf@2.9.0)':
     dependencies:
       '@bufbuild/protobuf': 2.9.0
 
@@ -2297,6 +2420,10 @@ snapshots:
   '@types/react@19.1.13':
     dependencies:
       csstype: 3.1.3
+
+  '@types/tar-stream@3.1.4':
+    dependencies:
+      '@types/node': 18.17.9
 
   '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.2.2))(eslint@8.53.0)(typescript@5.2.2)':
     dependencies:
@@ -2611,7 +2738,11 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.7.3: {}
+
   balanced-match@1.0.2: {}
+
+  bare-events@2.7.0: {}
 
   baseline-browser-mapping@2.8.4: {}
 
@@ -3098,6 +3229,10 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.7.0
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -3111,6 +3246,8 @@ snapshots:
       strip-final-newline: 3.0.0
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -3915,6 +4052,14 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamx@2.23.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.3
+    transitivePeerDependencies:
+      - react-native-b4a
+
   string.prototype.includes@2.0.1:
     dependencies:
       call-bind: 1.0.8
@@ -4012,6 +4157,20 @@ snapshots:
       resolve: 1.22.10
     transitivePeerDependencies:
       - ts-node
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.7.3
+      fast-fifo: 1.3.2
+      streamx: 2.23.0
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  text-decoder@1.2.3:
+    dependencies:
+      b4a: 1.7.3
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-table@0.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.1.13)(react@19.1.1)
+      react-syntax-highlighter:
+        specifier: ^15.6.6
+        version: 15.6.6(react@19.1.1)
       tailwindcss:
         specifier: ~3.1.3
         version: 3.1.8(postcss@8.4.31)
@@ -479,6 +482,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@2.3.10':
+    resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -878,11 +884,20 @@ packages:
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
+  character-entities-legacy@1.1.4:
+    resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
+  character-entities@1.2.4:
+    resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
+
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@1.1.4:
+    resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
@@ -907,6 +922,9 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  comma-separated-tokens@1.0.8:
+    resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1214,6 +1232,9 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
+  fault@1.0.4:
+    resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1245,6 +1266,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1352,11 +1377,23 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-parse-selector@2.2.5:
+    resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@6.0.0:
+    resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  highlightjs-vue@1.0.0:
+    resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -1395,8 +1432,14 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  is-alphabetical@1.0.4:
+    resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@1.0.4:
+    resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
 
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
@@ -1443,6 +1486,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@1.0.4:
+    resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
+
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
@@ -1461,6 +1507,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@1.0.4:
+    resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
@@ -1594,6 +1643,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lowlight@1.20.0:
+    resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1834,6 +1886,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@2.0.0:
+    resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -1929,8 +1984,19 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prismjs@1.27.0:
+    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
+    engines: {node: '>=6'}
+
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  property-information@5.6.0:
+    resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -1960,6 +2026,11 @@ packages:
       '@types/react': 19.1.13
       react: '>=18'
 
+  react-syntax-highlighter@15.6.6:
+    resolution: {integrity: sha512-DgXrc+AZF47+HvAPEmn7Ua/1p10jNoVZVI/LoPiYdtY+OM+/nG5yefLHKJwdKqY1adMuHFbeyBaG9j64ML7vTw==}
+    peerDependencies:
+      react: '>= 0.14.0'
+
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
@@ -1974,6 +2045,9 @@ packages:
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  refractor@3.6.0:
+    resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -2091,6 +2165,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@1.1.5:
+    resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -2675,6 +2752,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@2.3.10':
+    dependencies:
+      '@types/unist': 2.0.11
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -3085,9 +3166,15 @@ snapshots:
 
   character-entities-html4@2.1.0: {}
 
+  character-entities-legacy@1.1.4: {}
+
   character-entities-legacy@3.0.0: {}
 
+  character-entities@1.2.4: {}
+
   character-entities@2.0.2: {}
+
+  character-reference-invalid@1.1.4: {}
 
   character-reference-invalid@2.0.1: {}
 
@@ -3122,6 +3209,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
     optional: true
+
+  comma-separated-tokens@1.0.8: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -3583,6 +3672,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fault@1.0.4:
+    dependencies:
+      format: 0.2.2
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -3611,6 +3704,8 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  format@0.2.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -3732,6 +3827,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-parse-selector@2.2.5: {}
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -3755,6 +3852,18 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@6.0.0:
+    dependencies:
+      '@types/hast': 2.3.10
+      comma-separated-tokens: 1.0.8
+      hast-util-parse-selector: 2.2.5
+      property-information: 5.6.0
+      space-separated-tokens: 1.1.5
+
+  highlight.js@10.7.3: {}
+
+  highlightjs-vue@1.0.0: {}
 
   html-url-attributes@3.0.1: {}
 
@@ -3786,7 +3895,14 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  is-alphabetical@1.0.4: {}
+
   is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@1.0.4:
+    dependencies:
+      is-alphabetical: 1.0.4
+      is-decimal: 1.0.4
 
   is-alphanumerical@2.0.1:
     dependencies:
@@ -3844,6 +3960,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@1.0.4: {}
+
   is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
@@ -3862,6 +3980,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@1.0.4: {}
 
   is-hexadecimal@2.0.1: {}
 
@@ -3985,6 +4105,11 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lowlight@1.20.0:
+    dependencies:
+      fault: 1.0.4
+      highlight.js: 10.7.3
 
   math-intrinsics@1.1.0: {}
 
@@ -4360,6 +4485,15 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@2.0.0:
+    dependencies:
+      character-entities: 1.2.4
+      character-entities-legacy: 1.1.4
+      character-reference-invalid: 1.1.4
+      is-alphanumerical: 1.0.4
+      is-decimal: 1.0.4
+      is-hexadecimal: 1.0.4
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -4433,11 +4567,19 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  prismjs@1.27.0: {}
+
+  prismjs@1.30.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  property-information@5.6.0:
+    dependencies:
+      xtend: 4.0.2
 
   property-information@7.1.0: {}
 
@@ -4472,6 +4614,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-syntax-highlighter@15.6.6(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      highlight.js: 10.7.3
+      highlightjs-vue: 1.0.0
+      lowlight: 1.20.0
+      prismjs: 1.30.0
+      react: 19.1.1
+      refractor: 3.6.0
+
   react@19.1.1: {}
 
   read-cache@1.0.0:
@@ -4492,6 +4644,12 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  refractor@3.6.0:
+    dependencies:
+      hastscript: 6.0.0
+      parse-entities: 2.0.0
+      prismjs: 1.27.0
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -4666,6 +4824,8 @@ snapshots:
   slash@3.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  space-separated-tokens@1.1.5: {}
 
   space-separated-tokens@2.0.2: {}
 


### PR DESCRIPTION
Makes the module page wider, and beneath the existing two-column view, adds a full-width listing of stardocs if they are present on the module's source.json.

Fixes https://github.com/bazelbuild/bazel-central-registry/issues/5593