### PR TITLE
reapply "feat: show a warning for deprecated or archived modules" (#204)

### DIFF
--- a/pages/modules/[module].tsx
+++ b/pages/modules/[module].tsx
@@ -167,7 +167,9 @@ const ModulePage: NextPage<ModulePageProps> = ({
                       <>
                         <li
                           key={version.version}
-                          className="border rounded mt-2 "
+                          className={
+                            version.isYanked ? 'mt-2' : 'border rounded mt-2'
+                          }
                         >
                           {version.isYanked && (
                             <div


### PR DESCRIPTION
This time the yanked box looks better, the yellow rounded warning wraps the version info